### PR TITLE
Automatic setup of git user info and shellcheck with std syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,10 @@ git clone https://github.com/Mikroways/dotfiles.git ~/.dotfiles-mw
 Luego de correr los comandos anteriores se configurarán algunos programas
 utilizados desde la consola como por ejemplo:
 
-* zsh
-* vim
-* git
-* tmux
-
-## Pasos manuales requeridos
-
-El archivo gitconfig.local es necesario que se edite manualmente con los datos
-personales. Por ejemplo
-
-```ini
-[user]
-  name = Juan Perez
-  email = juan.perez@mikroways.net
-```
-
-> Se provee un archivo `gitconfig.local.sample` a modo de ejemplo que puede
-> copiarse como `gitconfig.local` y volver a correr el archivo
+- zsh
+- vim
+- git
+- tmux
 
 ## Cómo usar este repositorio
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ La forma de instalar estos dotfiles es tan simple como ejecutar:
 
 ```bash
 git clone https://github.com/Mikroways/dotfiles.git ~/.dotfiles-mw
-~/.dotfiles/scripts/install
+~/.dotfiles-wm/scripts/install
 ```
 
 Luego de correr los comandos anteriores se configurarán algunos programas

--- a/gitconfig
+++ b/gitconfig
@@ -24,7 +24,5 @@
   prune = true
 [rebase]
   autosquash = true
-[include]
-  path = ~/.gitconfig.local
 [diff]
   colorMoved = zebra

--- a/gitconfig.local.sample
+++ b/gitconfig.local.sample
@@ -1,3 +1,0 @@
-[user]
-  name = Juan Perez
-  email = juan.perez@mikroways.net

--- a/script/install
+++ b/script/install
@@ -1,22 +1,35 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-DIR=$(realpath "$(dirname $0)/../")
+DIR=$(realpath "$(dirname "$0")/../")
 BACKUP_DIR=$DIR/backup
 
-mkdir -p $BACKUP_DIR
+mkdir -p "${BACKUP_DIR}"
 
-cd $DIR
+cd "${DIR}"
 
 for file in *; do
-  [[ "$file" =~ (script|backup|README.md|.*sample$) ]] && continue
-  [ -e ~/.$file -a ! -L ~/.$file ] && mv ~/.$file $BACKUP_DIR
-  ln -fs $DIR/$file ~/.$file
+  files_dest=~/.${file}
+  [[ "${file}" =~ (script|backup|README.md|.*sample$) ]] && continue
+  [ -e "${files_dest}" ] && [ ! -L "${files_dest}" ] && mv "${files_dest}" "${BACKUP_DIR}"
+  ln -fs "${DIR}"/"${file}" "${files_dest}"
 done
 
 # Install vim-plug as autoload
 curl -sfLo ~/.vim/autoload/plug.vim --create-dirs \
-    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+  https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 # Install vim plugins
 vim +PlugUpdate +qall
+
+# Setup Git
+echo "Setting up git..."
+
+default_name=$(git config --global user.name)
+default_email=$(git config --global user.email)
+
+read -rp "Name [$default_name]: " name
+read -rp "Email [$default_email]: " email
+
+git config --global user.name "${name:-$default_name}"
+git config --global user.email "${email:-$default_email}"


### PR DESCRIPTION
Hi! This is just a small PR doing few changes:

- Automatic setup of git user info at the end of `./script/install` without required manual steps
- [shellcheck](https://www.shellcheck.net/) passed to bash scripts with standard configuration
- Updated `README.md` according to changes