### PR TITLE
Fix backup install script

### DIFF
--- a/script/install
+++ b/script/install
@@ -9,7 +9,7 @@ mkdir -p "$BACKUP_DIR"
 
 cd "$DIR"
 for file in *; do
-  [[ "$file" =~ (ssh|script|$BACKUP_DIR|README.*md|.*sample$) ]] && continue
+  [[ "$file" =~ (ssh|script|backup|README.*md|.*sample$) ]] && continue
   [ -e "$HOME/.$file" ] && [ ! -L "$HOME/.$file" ] && \
     mv "$HOME/.$file" "$BACKUP_DIR"
   ln -fs "$DIR/$file" "$HOME/.$file"


### PR DESCRIPTION
La expresion regular tenia la variable $BACKUP_DIR, que tiene la ruta completa a la carpeta de backup, por lo tanto no matcheaba con "backup" y no se ignoraba. Por lo tanto terminaba haciendo un link dentro de backup a si mismo.