### PR TITLE
fix(mw-tools-upgrade): corregir bugs, mejorar rendimiento y documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,40 @@ Las personalizaciones se pueden hacer en cascada de la siguiente forma:
   usuario configure sus credenciales, pero ahorramos la forma de conectarte
   agnósticamente a cada cliente. Aún nos queda el autocomplete de este comando.
 
+## Actualización automática de herramientas Mikroways
+
+Al abrir una nueva terminal, se lanza en background un chequeo de actualizaciones
+para todos los repositorios git bajo `~/.mikroways/`. Si hay novedades, se
+notifica al inicio de la **próxima** sesión de terminal.
+
+### Comportamiento
+
+- **Una vez por día**: el chequeo corre a lo sumo una vez diaria (controlado por
+  `~/.mw-tools-upgrade.lock`).
+- **Solo ramas principales**: los repositorios en una rama distinta a `main` o
+  `master` se reportan como advertencia pero no se actualizan automáticamente.
+- **Sin cambios locales**: si un repositorio tiene cambios sin commitear, se
+  aborta la actualización y se avisa.
+- **Notificaciones diferidas**: los avisos (actualizaciones disponibles, repos en
+  rama no principal, cambios locales sin commitear) se muestran al abrir la
+  siguiente terminal, no mientras el chequeo corre en background.
+
+### Comandos disponibles
+
+| Comando | Descripción |
+|---|---|
+| `mw-tools-upgrade` | Chequea actualizaciones de forma interactiva |
+| `mw-tools-upgrade -y` | Chequea y aplica automáticamente (modo background) |
+| `mw-tools-force-upgrade` | Fuerza el chequeo ignorando el lock diario |
+
+### Archivos relevantes
+
+| Archivo | Propósito |
+|---|---|
+| `~/.mw-tools-upgrade.lock` | Evita chequeos repetidos el mismo día |
+| `~/.mw-tools-upgrade.warn` | Mensajes pendientes a mostrar en la próxima terminal |
+| `~/.mw-tools-upgrade.log` | Log del último chequeo en background |
+
 ## Sobre vim
 
 Dejamos algunos [tips sobre vim que hemos configurado con estos

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ notifica al inicio de la **próxima** sesión de terminal.
 
 ### Comportamiento
 
-- **Una vez por día**: el chequeo corre a lo sumo una vez diaria (controlado por
+* **Una vez por día**: el chequeo corre a lo sumo una vez diaria (controlado por
   `~/.mw-tools-upgrade.lock`).
-- **Solo ramas principales**: los repositorios en una rama distinta a `main` o
+* **Solo ramas principales**: los repositorios en una rama distinta a `main` o
   `master` se reportan como advertencia pero no se actualizan automáticamente.
-- **Sin cambios locales**: si un repositorio tiene cambios sin commitear, se
+* **Sin cambios locales**: si un repositorio tiene cambios sin commitear, se
   aborta la actualización y se avisa.
-- **Notificaciones diferidas**: los avisos (actualizaciones disponibles, repos en
+* **Notificaciones diferidas**: los avisos (actualizaciones disponibles, repos en
   rama no principal, cambios locales sin commitear) se muestran al abrir la
   siguiente terminal, no mientras el chequeo corre en background.
 
@@ -84,9 +84,11 @@ notifica al inicio de la **próxima** sesión de terminal.
 
 | Comando | Descripción |
 |---|---|
-| `mw-tools-upgrade` | Chequea actualizaciones de forma interactiva |
-| `mw-tools-upgrade -y` | Chequea y aplica automáticamente (modo background) |
-| `mw-tools-force-upgrade` | Fuerza el chequeo ignorando el lock diario |
+| `mw-tools-upgrade` | Chequea actualizaciones una vez por día (interactivo) |
+| `mw-tools-upgrade -y` | Igual pero aplica automáticamente sin preguntar |
+| `mw-tools-upgrade -v` | Muestra el output completo del fetch por repo |
+| `mw-tools-force-upgrade` | Igual a `mw-tools-upgrade` pero ignora el lock diario — no hace falta borrar el lock manualmente |
+| `mw-tools-force-upgrade -v` | Force + verbose |
 
 ### Archivos relevantes
 

--- a/README.md
+++ b/README.md
@@ -35,32 +35,32 @@ personales. Por ejemplo
 
 La idea es que cada integrante de Mikroways utilice este repositorio como punto
 de partida, pero personalice su ambiente como mejor le parezca, agregando nuevas
-configuraciones y proponiéndolas al repositorio raiz, compartiendo experiencias
+configuraciones y proponiéndolas al repositorio raíz, compartiendo experiencias
 que nos hagan más eficientes en el día a día.
 Para ello se puede forkear este repositorio y cualquier contribución realizarla
 como un Pull Request.
 
-### Personalizacions de Mikroways y Usuario
+### Personalizaciones de Mikroways y Usuario
 
-Las personalizaciones se pueden hacer en casacada de la siguiente forma:
+Las personalizaciones se pueden hacer en cascada de la siguiente forma:
 
 1. Primero se setean los valores por defecto en `.zshrc`
-1. Luego se personalizacion los valores por defecto para Mikroways usando
+1. Luego se personalizan los valores por defecto para Mikroways usando
    `.zshrc.mikroways`
 1. Finalmente, un usuario puede crear un archivo `.zshrc.user` que idealmente
    conviene no versionarlo en este repositorio con las personalizaciones que
-   desea sobreescrbir
+   desea sobreescribir
 1. Respecto a los bundles de antigen, es posible aplicar personalizaciones con:
   `.zshrc.mikroways.antigen.bundles` y `.zshrc.user.antigen.bundles`
 
 ## Integración con herramientas propias de mikroways
 
-* zshell autocomplete y configuraciones de ssh comartidas mediante [mw-sshconfig-sync](https://gitlab.com/mikroways/tools/mw-sshconfig-sync)
+* zshell autocomplete y configuraciones de ssh compartidas mediante [mw-sshconfig-sync](https://gitlab.com/mikroways/tools/mw-sshconfig-sync)
   o simplemente usando el cliente de nextcloud.
 * Conexión a las vpn de nuestros clientes usando
   [mw-vpn](https://gitlab.com/mikroways/tools/mw-vpn/). La idea es que cada
   usuario configure sus credenciales, pero ahorramos la forma de conectarte
-  agnósticamente a cada cliente. Aun nos queda el autocomplete de este comando.
+  agnósticamente a cada cliente. Aún nos queda el autocomplete de este comando.
 
 ## Sobre vim
 

--- a/README.vim.md
+++ b/README.vim.md
@@ -40,8 +40,27 @@ ventanas y solapas.
 
 ## Uso de solapas
 
-Al abrir vim podemos además usar la opción `-p` para abrir varios archivos en
-solapas.
+Al abrir vim podemos usar la opción `-p` para abrir varios archivos en solapas:
+
+```bash
+vim -p archivo1 archivo2 archivo3
+```
+
+Desde dentro de vim también podemos abrir nuevas solapas:
+
+* `:tabnew <archivo>` abre un archivo en una solapa nueva
+* `:tabnew` abre una solapa vacía
+
+Para navegar entre solapas:
+
+* `gt` va a la solapa siguiente
+* `gT` va a la solapa anterior
+* `<número>gt` va directamente a la solapa número `<número>` (ej: `2gt`)
+
+Para cerrar solapas:
+
+* `:tabclose` cierra la solapa actual
+* `:tabonly` cierra todas las solapas excepto la actual
 
 ## Uso de ventanas
 

--- a/README.vim.md
+++ b/README.vim.md
@@ -11,6 +11,10 @@ instalan con [vim-plug](https://github.com/junegunn/vim-plug).
 
 ## Grabar acciones repetitivas
 
+Para grabar una secuencia de comandos, se usa `q` seguido de una letra (ej: `qa`
+para grabar en el registro `a`). Para detener la grabación, se usa `q` nuevamente.
+Para ejecutar la macro grabada, se usa `@a` (o `@@` para repetir la última).
+
 ## Ver las diferencias de un archivo modificado
 
 ```vim
@@ -35,8 +39,6 @@ pero utilizando Ctrl+t. Esta utilidad en vim puede utilizarse en combinación de
 ventanas y solapas.
 
 ## Uso de solapas
-
-TODO
 
 Al abrir vim podemos además usar la opción `-p` para abrir varios archivos en
 solapas.

--- a/README.vim.md
+++ b/README.vim.md
@@ -13,7 +13,7 @@ instalan con [vim-plug](https://github.com/junegunn/vim-plug).
 
 ## Ver las diferencias de un archivo modificado
 
-```
+```vim
 :w !diff % -
 ```
 
@@ -31,7 +31,7 @@ instalan con [vim-plug](https://github.com/junegunn/vim-plug).
 Para abrir un archivo bajo el árbol de directorios desde donde se abrió vim,
 podemos usar Ctrl+p. Esta acción invoca al comando `fzf` o [fuzzy
 finder](https://github.com/junegunn/fzf), que también funciona desde la consola,
-pero utilizando Ctrl+t. Esta utilidad en vim puede utilizarse en combinación de 
+pero utilizando Ctrl+t. Esta utilidad en vim puede utilizarse en combinación de
 ventanas y solapas.
 
 ## Uso de solapas

--- a/gitconfig
+++ b/gitconfig
@@ -1,6 +1,3 @@
-#[init]
-#  defaultBranch = main
-#  templatedir = ~/.git_template
 [push]
   default = current
 [color]

--- a/gitmessage
+++ b/gitmessage
@@ -2,7 +2,7 @@
 
 # 50-caracteres para el asunto del commit
 #
-# 72-caracteres como máximo para la descripción. Esta descricpción
+# 72-caracteres como máximo para la descripción. Esta descripción
 # debe responder:
 #
 # * ¿Por qué este cambio es necesario?

--- a/zshrc
+++ b/zshrc
@@ -1,3 +1,7 @@
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
 # Set PATH to use asdf
 export ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
 path=("$ASDF_DATA_DIR/bin" $path)
@@ -21,7 +25,7 @@ bindkey "^u" backward-kill-line
 # Alias for common extensions
 alias -s {yaml,yml,json,md}=$EDITOR
 
-# Fix GPG AGENT 
+# Fix GPG AGENT
 export GPG_TTY=$TTY
 
 source ~/.antigen.zsh/antigen.zsh
@@ -46,7 +50,7 @@ antigen theme romkatv/powerlevel10k
 # Tell Antigen that you're done.
 antigen apply
 
-# Do not share hsitory between sessions
+# Do not share history between sessions
 unsetopt share_history
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
@@ -55,7 +59,7 @@ unsetopt share_history
 # Fuzzy find
 [[ -f ~/.fzf.zsh ]] && source ~/.fzf.zsh
 
-# Load custom autocmplete
+# Load custom autocomplete
 fpath=($HOME/.zsh/completion $fpath)
 
 
@@ -64,7 +68,3 @@ fpath=($HOME/.zsh/completion $fpath)
 
 # Load Other User personalizations
 [ -f ~/.zshrc.user ] && source ~/.zshrc.user
-
-if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
-  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
-fi

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -18,6 +18,7 @@ function mw-tools-upgrade() {
   local today=$(date +%Y-%m-%d)
   local REPOS_TO_UPDATE=()
   local REPOS_WITH_LOCAL_UPDATES=()
+  local REPOS_NOT_ON_MAIN=()
 
 
   # Verifica si ya se revisó hoy
@@ -28,12 +29,18 @@ function mw-tools-upgrade() {
 
   echo "$today" > "$GIT_UPDATE_CHECK_FILE"
   for repo_dir in "${WATCHED_DIRS[@]}"; do
-    IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^main|master$")
+    IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^(main|master)$")
     if [[ -z "$IS_MAIN_BRANCH" ]]; then
       echo "  📢 Repository is not using main branch for $repo_dir. Please review"
+      REPOS_NOT_ON_MAIN+=( $(basename $repo_dir) )
     fi
   done
+  if [[ "${#REPOS_NOT_ON_MAIN[@]}" -ne 0 ]]; then
+    [[ $auto_yes -eq 1 ]] && echo "  📢 mw-tools: repos en rama no principal: ${(j:, :)REPOS_NOT_ON_MAIN}" >> "${HOME}/.mw-tools-upgrade.warn"
+  fi
   for repo_dir in "${WATCHED_DIRS[@]}"; do
+    IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^(main|master)$")
+    [[ -z "$IS_MAIN_BRANCH" ]] && continue
     LOCAL_UPDATES=$(LC_ALL=C git -C $repo_dir status | grep -E "modified:|Untracked")
     if [[ ! -z "$LOCAL_UPDATES" ]]; then
       echo "  🚩 There are local updates for $repo_dir"
@@ -48,6 +55,8 @@ function mw-tools-upgrade() {
   fi
   echo "Updating remotes for..."
   for repo_dir in "${WATCHED_DIRS[@]}"; do
+    IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^(main|master)$")
+    [[ -z "$IS_MAIN_BRANCH" ]] && continue
     echo "- $(basename $repo_dir)"
     git -C $repo_dir remote update &>/dev/null
     UPDATES=$(LC_ALL=C git -C $repo_dir status -uno | grep "Your branch is behind")

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -6,16 +6,23 @@ WATCHED_DIRS=(${(f)"$(find $HOME/.mikroways -type d -name .git -exec dirname {} 
 GIT_UPDATE_CHECK_FILE="${HOME}/.mw-tools-upgrade.lock"
 
 function mw-tools-force-upgrade() {
+  echo "Forzando chequeo (ignorando lock diario)..."
   rm -f $GIT_UPDATE_CHECK_FILE
   mw-tools-upgrade "$@"
 }
 
-# Check for updates. Pass -y to auto-apply without prompt (useful for background/cron runs).
+# Check for updates.
+# Flags: -y auto-apply without prompt (background/cron), -v verbose fetch output
 function mw-tools-upgrade() {
   local auto_yes=0
-  [[ "${1:-}" == "-y" ]] && auto_yes=1
+  local verbose=0
+  for arg in "$@"; do
+    [[ "$arg" == "-y" ]] && auto_yes=1
+    [[ "$arg" == "-v" ]] && verbose=1
+  done
 
   local today=$(date +%Y-%m-%d)
+  local REPOS_MAIN=()
   local REPOS_TO_UPDATE=()
   local REPOS_WITH_LOCAL_UPDATES=()
   local REPOS_NOT_ON_MAIN=()
@@ -23,29 +30,31 @@ function mw-tools-upgrade() {
   local REPOS_UPDATED=()
   local REPOS_PULL_FAILED=()
 
-
   # Verifica si ya se revisó hoy
   if [[ -f "$GIT_UPDATE_CHECK_FILE" && $(cat "$GIT_UPDATE_CHECK_FILE") == "$today" ]]; then
     return
   fi
   echo "Checking for Mikroways tools updates...."
-
   echo "$today" > "$GIT_UPDATE_CHECK_FILE"
+
+  # Clasificar repos por rama
   for repo_dir in "${WATCHED_DIRS[@]}"; do
     IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^(main|master)$")
     if [[ -z "$IS_MAIN_BRANCH" ]]; then
       echo "  📢 Repository is not using main branch for $repo_dir. Please review"
       REPOS_NOT_ON_MAIN+=( $(basename $repo_dir) )
+    else
+      REPOS_MAIN+=( $repo_dir )
     fi
   done
   if [[ "${#REPOS_NOT_ON_MAIN[@]}" -ne 0 ]]; then
     [[ $auto_yes -eq 1 ]] && echo "  📢 mw-tools: repos en rama no principal: ${(j:, :)REPOS_NOT_ON_MAIN}" >> "${HOME}/.mw-tools-upgrade.warn"
   fi
-  for repo_dir in "${WATCHED_DIRS[@]}"; do
-    IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^(main|master)$")
-    [[ -z "$IS_MAIN_BRANCH" ]] && continue
+
+  # Verificar cambios locales (solo repos en rama principal)
+  for repo_dir in "${REPOS_MAIN[@]}"; do
     LOCAL_UPDATES=$(LC_ALL=C git -C $repo_dir status | grep -E "modified:|Untracked")
-    if [[ ! -z "$LOCAL_UPDATES" ]]; then
+    if [[ -n "$LOCAL_UPDATES" ]]; then
       echo "  🚩 There are local updates for $repo_dir"
       echo "     Verify changes and commit them. Share your changes"
       REPOS_WITH_LOCAL_UPDATES+=( $(basename $repo_dir) )
@@ -56,22 +65,50 @@ function mw-tools-upgrade() {
     [[ $auto_yes -eq 1 ]] && echo "  🚩 mw-tools: cambios locales sin commitear en: ${(j:, :)REPOS_WITH_LOCAL_UPDATES}" >> "${HOME}/.mw-tools-upgrade.warn"
     return
   fi
-  echo "Updating remotes for..."
-  for repo_dir in "${WATCHED_DIRS[@]}"; do
-    IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^(main|master)$")
-    [[ -z "$IS_MAIN_BRANCH" ]] && continue
+
+  # Fetch remotes en paralelo (ambos modos)
+  local tmpdir=$(mktemp -d)
+  echo "Fetching remotes..."
+  setopt LOCAL_OPTIONS
+  unsetopt MONITOR
+  for repo_dir in "${REPOS_MAIN[@]}"; do
+    local key="${repo_dir//\//_}"
+    {
+      if git -C $repo_dir remote update &>/dev/null; then
+        echo 0
+      else
+        echo 1
+      fi
+    } > "$tmpdir/$key" &
+  done
+  wait
+
+  # Verificar resultados
+  echo "Checking for updates..."
+  for repo_dir in "${REPOS_MAIN[@]}"; do
+    local key="${repo_dir//\//_}"
+    local fetch_exit=$(cat "$tmpdir/$key" 2>/dev/null)
     echo "- $(basename $repo_dir)"
-    if ! git -C $repo_dir remote update &>/dev/null; then
+    if [[ "$fetch_exit" != "0" ]]; then
       echo "  ❌ Error al hacer fetch de $(basename $repo_dir)"
       REPOS_WITH_FETCH_ERROR+=( $(basename $repo_dir) )
       continue
     fi
     UPDATES=$(LC_ALL=C git -C $repo_dir status -uno | grep -E "Your branch is behind|have diverged")
-    if [[ ! -z "$UPDATES" ]]; then
+    if [[ -n "$UPDATES" ]]; then
+      local remote_branch="origin/$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD)"
+      local new_commits=$(git -C $repo_dir log HEAD..$remote_branch --oneline 2>/dev/null)
       echo "  ⚠️  There are updates for $repo_dir"
+      if [[ $verbose -eq 1 && -n "$new_commits" ]]; then
+        echo "$new_commits" | while IFS= read -r line; do
+          echo "     $line"
+        done
+      fi
       REPOS_TO_UPDATE+=( $repo_dir )
     fi
   done
+  rm -rf $tmpdir
+
   if [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]]; then
     [[ $auto_yes -eq 1 ]] && echo "  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}" >> "${HOME}/.mw-tools-upgrade.warn"
   fi

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -19,6 +19,9 @@ function mw-tools-upgrade() {
   local REPOS_TO_UPDATE=()
   local REPOS_WITH_LOCAL_UPDATES=()
   local REPOS_NOT_ON_MAIN=()
+  local REPOS_WITH_FETCH_ERROR=()
+  local REPOS_UPDATED=()
+  local REPOS_PULL_FAILED=()
 
 
   # Verifica si ya se revisó hoy
@@ -58,13 +61,20 @@ function mw-tools-upgrade() {
     IS_MAIN_BRANCH=$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD | grep -iE "^(main|master)$")
     [[ -z "$IS_MAIN_BRANCH" ]] && continue
     echo "- $(basename $repo_dir)"
-    git -C $repo_dir remote update &>/dev/null
-    UPDATES=$(LC_ALL=C git -C $repo_dir status -uno | grep "Your branch is behind")
+    if ! git -C $repo_dir remote update &>/dev/null; then
+      echo "  ❌ Error al hacer fetch de $(basename $repo_dir)"
+      REPOS_WITH_FETCH_ERROR+=( $(basename $repo_dir) )
+      continue
+    fi
+    UPDATES=$(LC_ALL=C git -C $repo_dir status -uno | grep -E "Your branch is behind|have diverged")
     if [[ ! -z "$UPDATES" ]]; then
       echo "  ⚠️  There are updates for $repo_dir"
       REPOS_TO_UPDATE+=( $repo_dir )
     fi
   done
+  if [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]]; then
+    [[ $auto_yes -eq 1 ]] && echo "  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}" >> "${HOME}/.mw-tools-upgrade.warn"
+  fi
   if [[ "${#REPOS_TO_UPDATE[@]}" -ne 0 ]]; then
     local answer
     if [[ $auto_yes -eq 1 ]]; then
@@ -75,11 +85,18 @@ function mw-tools-upgrade() {
     fi
     if [[ "$( echo $answer | tr '[:upper:]' '[:lower:]')" == "y" ]]; then
       for repo_dir in "${REPOS_TO_UPDATE[@]}"; do
-        git -C $repo_dir pull
+        if git -C $repo_dir pull; then
+          REPOS_UPDATED+=( $repo_dir )
+        else
+          echo "  ❌ Error al actualizar $(basename $repo_dir)"
+          REPOS_PULL_FAILED+=( $(basename $repo_dir) )
+        fi
       done
       echo
-      echo "  ✔️  Mikroways tools updated"
-      [[ $auto_yes -eq 1 ]] && echo "  ✔️  mw-tools: actualizadas: ${(j:, :)REPOS_TO_UPDATE:t}" >> "${HOME}/.mw-tools-upgrade.warn"
+      [[ "${#REPOS_UPDATED[@]}" -ne 0 ]] && echo "  ✔️  Mikroways tools updated: ${(j:, :)REPOS_UPDATED:t}"
+      [[ "${#REPOS_UPDATED[@]}" -ne 0 && $auto_yes -eq 1 ]] && echo "  ✔️  mw-tools: actualizadas: ${(j:, :)REPOS_UPDATED:t}" >> "${HOME}/.mw-tools-upgrade.warn"
+      [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 ]] && echo "  ❌ Falló el pull de: ${(j:, :)REPOS_PULL_FAILED}"
+      [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 && $auto_yes -eq 1 ]] && echo "  ❌ mw-tools: falló el pull de: ${(j:, :)REPOS_PULL_FAILED}" >> "${HOME}/.mw-tools-upgrade.warn"
     else
       echo "  ❌ Omit updates for Mikroways tools"
     fi

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -68,7 +68,7 @@ function mw-tools-upgrade() {
 
   # Fetch remotes en paralelo (ambos modos)
   local tmpdir=$(mktemp -d)
-  echo "Fetching remotes..."
+  local fetch_pids=()
   setopt LOCAL_OPTIONS
   unsetopt MONITOR
   for repo_dir in "${REPOS_MAIN[@]}"; do
@@ -76,14 +76,37 @@ function mw-tools-upgrade() {
     {
       local err
       if err=$(git -C $repo_dir remote update 2>&1 >/dev/null); then
-        echo 0
+        echo 0 > "$tmpdir/$key.tmp"
       else
-        echo 1
-        echo "$err" | grep -E "^(fatal|error|ERROR):" | head -1
+        { echo 1; echo "$err" | grep -E "^(fatal|error|ERROR):" | head -1 } > "$tmpdir/$key.tmp"
       fi
-    } > "$tmpdir/$key" &
+      mv "$tmpdir/$key.tmp" "$tmpdir/$key"
+    } &
+    fetch_pids+=($!)
   done
-  wait
+
+  if [[ $auto_yes -eq 0 ]]; then
+    local total=${#REPOS_MAIN}
+    local bar_width=20
+    while true; do
+      local completed=$(find "$tmpdir" -type f -not -name "*.tmp" | wc -l | tr -d ' ')
+      local filled=$(( completed * bar_width / total ))
+      local empty=$(( bar_width - filled ))
+      local bar=""
+      [[ $filled -gt 0 ]] && bar=$(printf '%.0s█' {1..$filled})
+      [[ $empty -gt 0 ]] && bar+=$(printf '%.0s░' {1..$empty})
+      printf "\r  Fetching remotes... [%s] %d/%d" "$bar" "$completed" "$total"
+      [[ $completed -ge $total ]] && break
+      sleep 0.1
+    done
+    printf "\n"
+  else
+    echo "Fetching remotes..."
+  fi
+
+  for pid in "${fetch_pids[@]}"; do
+    wait $pid 2>/dev/null
+  done
 
   # Verificar resultados
   echo "Checking for updates..."

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -74,10 +74,12 @@ function mw-tools-upgrade() {
   for repo_dir in "${REPOS_MAIN[@]}"; do
     local key="${repo_dir//\//_}"
     {
-      if git -C $repo_dir remote update &>/dev/null; then
+      local err
+      if err=$(git -C $repo_dir remote update 2>&1 >/dev/null); then
         echo 0
       else
         echo 1
+        echo "$err" | grep -E "^(fatal|error|ERROR):" | head -1
       fi
     } > "$tmpdir/$key" &
   done
@@ -87,24 +89,27 @@ function mw-tools-upgrade() {
   echo "Checking for updates..."
   for repo_dir in "${REPOS_MAIN[@]}"; do
     local key="${repo_dir//\//_}"
-    local fetch_exit=$(cat "$tmpdir/$key" 2>/dev/null)
-    echo "- $(basename $repo_dir)"
+    local repo_name=$(basename $repo_dir)
+    local fetch_exit=$(head -1 "$tmpdir/$key" 2>/dev/null)
+    local fetch_error=$(tail -n +2 "$tmpdir/$key" 2>/dev/null)
     if [[ "$fetch_exit" != "0" ]]; then
-      echo "  ❌ Error al hacer fetch de $(basename $repo_dir)"
-      REPOS_WITH_FETCH_ERROR+=( $(basename $repo_dir) )
+      echo "- $repo_name ❌  ${fetch_error:-fetch failed}"
+      REPOS_WITH_FETCH_ERROR+=( $repo_name )
       continue
     fi
     UPDATES=$(LC_ALL=C git -C $repo_dir status -uno | grep -E "Your branch is behind|have diverged")
     if [[ -n "$UPDATES" ]]; then
       local remote_branch="origin/$(LC_ALL=C git -C $repo_dir rev-parse --abbrev-ref HEAD)"
       local new_commits=$(git -C $repo_dir log HEAD..$remote_branch --oneline 2>/dev/null)
-      echo "  ⚠️  There are updates for $repo_dir"
+      echo "- $repo_name ⚠️"
       if [[ $verbose -eq 1 && -n "$new_commits" ]]; then
         echo "$new_commits" | while IFS= read -r line; do
           echo "     $line"
         done
       fi
       REPOS_TO_UPDATE+=( $repo_dir )
+    else
+      echo "- $repo_name ✔️"
     fi
   done
   rm -rf $tmpdir

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -112,6 +112,9 @@ function mw-tools-upgrade() {
   if [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]]; then
     [[ $auto_yes -eq 1 ]] && echo "  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}" >> "${HOME}/.mw-tools-upgrade.warn"
   fi
+  if [[ "${#REPOS_TO_UPDATE[@]}" -eq 0 && "${#REPOS_WITH_FETCH_ERROR[@]}" -eq 0 ]]; then
+    echo "  ✔️  All tools up to date"
+  fi
   if [[ "${#REPOS_TO_UPDATE[@]}" -ne 0 ]]; then
     local answer
     if [[ $auto_yes -eq 1 ]]; then


### PR DESCRIPTION
## Resumen

### Bugs corregidos
- Advertencia de repos en rama no principal no aparecía al abrir terminal en modo background: ahora escribe al `.warn` para mostrarse en la siguiente sesión
- Repos en ramas feature excluidos de los ciclos de local-check y remote update/pull
- Regex `^main|master$` → `^(main|master)$`
- Errores de fetch y pull ya no abortan el resto de repos — se reportan individualmente y continúa con los demás
- Repos divergidos (ahead + behind) ahora también se detectan y se intenta el pull

### Mejoras de rendimiento
- Fetch de remotes en paralelo (~6x más rápido, ~13s vs ~1m26s)
- Barra de progreso en tiempo real durante el fetch (solo en modo interactivo)

### Mejoras de UX
- Estado por repo en la misma línea: `- mw-aws-profile ✔️` / `❌ ERROR: ...` / `⚠️`
- Nuevo flag `-v`: muestra commits nuevos disponibles por repo cuando hay updates
- `mw-tools-force-upgrade` imprime mensaje indicando que ignora el lock diario
- Mensaje `✔️ All tools up to date` cuando no hay nada que actualizar

### Documentación y calidad
- Nueva sección en README explicando el mecanismo de actualización automática, comandos disponibles y archivos relevantes
- Correcciones de ortografía en README, README.vim.md y gitmessage
- Sección de macros y solapas completada en README.vim.md
- `zshrc`: p10k-instant-prompt movido al inicio del archivo (era inefectivo al final), typos corregidos
- `gitconfig`: sección `[init]` comentada duplicada eliminada

## Plan de prueba

- [ ] Abrir terminal con repo en feature branch → siguiente terminal muestra `📢 mw-tools: repos en rama no principal`
- [ ] Verificar que repos en feature branch no aparecen en "Checking for updates..."
- [ ] Simular fetch fallido (URL inválida en un remote) → muestra `❌` con error real y continúa con los demás
- [ ] Simular pull fallido (repo divergido con conflicto) → muestra `❌` y continúa con los demás
- [ ] Comparar `time ( mw-tools-force-upgrade )` vs versión anterior — debería ser ~6x más rápido
- [ ] Verificar que la barra de progreso avanza en tiempo real durante el fetch
- [ ] `mw-tools-force-upgrade -v` muestra commits nuevos cuando hay updates disponibles
- [ ] Sin updates → termina con `✔️ All tools up to date`