### PR TITLE
feat: instalar mw-skills automáticamente para Claude Code y gemini-cli

### DIFF
--- a/zshrc.mikroways
+++ b/zshrc.mikroways
@@ -46,20 +46,17 @@ export MW_BOOTSTRAP_ROOT="$HOME/.mikroways/tools/mw-bootstrap"
   fpath=($MW_BOOTSTRAP_ROOT/shell-completion/zsh $fpath)
 
 # Enable mw skills (Claude Code + gemini-cli)
-MW_SKILLS_ROOT="$HOME/.mikroways/tools/mw-skills/skills"
-if [[ -d "$MW_SKILLS_ROOT" ]]; then
-  for _mw_skill_dir in "$MW_SKILLS_ROOT"/*/; do
-    _mw_skill_name=$(basename "$_mw_skill_dir")
-    # Claude Code
-    [[ ! -e "$HOME/.claude/skills/$_mw_skill_name" ]] && \
-      ln -s "$_mw_skill_dir" "$HOME/.claude/skills/$_mw_skill_name" 2>/dev/null
-    # gemini-cli
-    if [[ ! -e "$HOME/.gemini/skills/$_mw_skill_name" ]] && command -v gemini &>/dev/null; then
-      gemini skills link "$_mw_skill_dir" --consent 2>/dev/null
-    fi
-  done
-  unset _mw_skill_dir _mw_skill_name
-fi
+# Los skills viven en cada marco; sparse clones bajo ~/.mikroways/marcos-tecnicos/
+for _mw_skill_dir in "$HOME/.mikroways/marcos-tecnicos"/*/skills/*/; do
+  [[ -d "$_mw_skill_dir" ]] || continue
+  _mw_skill_name=$(basename "$_mw_skill_dir")
+  [[ ! -e "$HOME/.claude/skills/$_mw_skill_name" ]] && \
+    ln -s "$_mw_skill_dir" "$HOME/.claude/skills/$_mw_skill_name" 2>/dev/null
+  if [[ ! -e "$HOME/.gemini/skills/$_mw_skill_name" ]] && command -v gemini &>/dev/null; then
+    gemini skills link "$_mw_skill_dir" --consent 2>/dev/null
+  fi
+done
+unset _mw_skill_dir _mw_skill_name
 
 # -----------------------------------------------------------------------------
 # Enable krew

--- a/zshrc.mikroways
+++ b/zshrc.mikroways
@@ -46,8 +46,8 @@ export MW_BOOTSTRAP_ROOT="$HOME/.mikroways/tools/mw-bootstrap"
   fpath=($MW_BOOTSTRAP_ROOT/shell-completion/zsh $fpath)
 
 # Enable mw skills (Claude Code + gemini-cli)
-# Los skills viven en cada marco; sparse clones bajo ~/.mikroways/marcos-tecnicos/
-for _mw_skill_dir in "$HOME/.mikroways/marcos-tecnicos"/*/skills/*/; do
+# Los skills viven en cada marco; sparse clones bajo ~/.mikroways/tools/mw-skills/sources/
+for _mw_skill_dir in "$HOME/.mikroways/tools/mw-skills/sources"/*/skills/*/; do
   [[ -d "$_mw_skill_dir" ]] || continue
   _mw_skill_name=$(basename "$_mw_skill_dir")
   [[ ! -e "$HOME/.claude/skills/$_mw_skill_name" ]] && \

--- a/zshrc.mikroways
+++ b/zshrc.mikroways
@@ -45,6 +45,22 @@ export MW_BOOTSTRAP_ROOT="$HOME/.mikroways/tools/mw-bootstrap"
 [[ -x $MW_BOOTSTRAP_ROOT/bin/mw-bootstrap ]] && export PATH="$MW_BOOTSTRAP_ROOT/bin:$PATH" && \
   fpath=($MW_BOOTSTRAP_ROOT/shell-completion/zsh $fpath)
 
+# Enable mw skills (Claude Code + gemini-cli)
+MW_SKILLS_ROOT="$HOME/.mikroways/tools/mw-skills/skills"
+if [[ -d "$MW_SKILLS_ROOT" ]]; then
+  for _mw_skill_dir in "$MW_SKILLS_ROOT"/*/; do
+    _mw_skill_name=$(basename "$_mw_skill_dir")
+    # Claude Code
+    [[ ! -e "$HOME/.claude/skills/$_mw_skill_name" ]] && \
+      ln -s "$_mw_skill_dir" "$HOME/.claude/skills/$_mw_skill_name" 2>/dev/null
+    # gemini-cli
+    if [[ ! -e "$HOME/.gemini/skills/$_mw_skill_name" ]] && command -v gemini &>/dev/null; then
+      gemini skills link "$_mw_skill_dir" --consent 2>/dev/null
+    fi
+  done
+  unset _mw_skill_dir _mw_skill_name
+fi
+
 # -----------------------------------------------------------------------------
 # Enable krew
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Agrega snippet en `zshrc.mikroways` que instala automáticamente los skills del repo `~/.mikroways/tools/mw-skills` en Claude Code (symlinks en `~/.claude/skills/`) y gemini-cli (`gemini skills link`) al abrir terminal
- El snippet es idempotente: omite skills ya instalados
- Requiere que `mw-skills` esté clonado en `~/.mikroways/tools/mw-skills`; si no está presente, el bloque no hace nada

Relacionado con: https://proyectos.mikroways.net/issues/17132