### PR TITLE
Agrega notificaciones persistentes y tests para mw-tools-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,13 @@ notifica al inicio de la **próxima** sesión de terminal.
   `master` se reportan como advertencia pero no se actualizan automáticamente.
 * **Sin cambios locales**: si un repositorio tiene cambios sin commitear, se
   aborta la actualización y se avisa.
-* **Notificaciones diferidas**: los avisos (actualizaciones disponibles, repos en
-  rama no principal, cambios locales sin commitear) se muestran al abrir la
-  siguiente terminal, no mientras el chequeo corre en background.
+* **Notificaciones diferidas**: los avisos se muestran al abrir la siguiente
+  terminal, no mientras el chequeo corre en background. Hay dos tipos:
+  * **Problemas** (`.warn`): cambios locales sin commitear, repo en rama no
+    principal, errores de fetch/pull — persisten en cada terminal hasta que se
+    resuelvan.
+  * **Actualizaciones** (`.notify`): repos actualizados correctamente — se
+    muestran una sola vez y se eliminan automáticamente.
 
 ### Comandos disponibles
 
@@ -104,8 +108,18 @@ notifica al inicio de la **próxima** sesión de terminal.
 | Archivo | Propósito |
 |---|---|
 | `~/.mw-tools-upgrade.lock` | Evita chequeos repetidos el mismo día |
-| `~/.mw-tools-upgrade.warn` | Mensajes pendientes a mostrar en la próxima terminal |
+| `~/.mw-tools-upgrade.warn` | Problemas que requieren acción (persiste hasta resolverlos) |
+| `~/.mw-tools-upgrade.notify` | Notificación de repos actualizados (se elimina al mostrarse) |
 | `~/.mw-tools-upgrade.log` | Log del último chequeo en background |
+
+### Tests
+
+El comportamiento del sistema de updates está cubierto por `test-updates.sh`:
+
+```sh
+zsh test-updates.sh        # corre todos los tests
+zsh test-updates.sh -v     # verbose: muestra estado de archivos y log en cada test
+```
 
 ## Sobre vim
 

--- a/test-updates.sh
+++ b/test-updates.sh
@@ -22,9 +22,9 @@ section() { echo "\n${YELLOW}${BOLD}$1${NC}" }
 TMPDIR_TEST=$(mktemp -d)
 export HOME="$TMPDIR_TEST"
 WARN="${HOME}/.mw-tools-upgrade.warn"
+NOTIFY="${HOME}/.mw-tools-upgrade.notify"
 LOCK="${HOME}/.mw-tools-upgrade.lock"
 LOG="${HOME}/.mw-tools-upgrade.log"
-PENDING="${HOME}/.mw-tools-upgrade.pending"
 
 cleanup() { rm -rf "$TMPDIR_TEST" }
 trap cleanup EXIT
@@ -95,13 +95,12 @@ _show_file_content() {
   fi
 }
 
-# Muestra el estado de lock/warn/pending/log antes de correr
 _show_before() {
   [[ $VERBOSE -eq 0 ]] && return
   echo "${CYAN}  Antes:${NC}"
   _show_file_content "lock" "$LOCK"
   _show_file_content "warn" "$WARN"
-  _show_file_content "pending" "$PENDING"
+  _show_file_content "notify" "$NOTIFY"
   if [[ -f "$LOG" ]]; then
     echo "${GRAY}    log:  $(wc -l < $LOG) líneas existentes${NC}"
   else
@@ -109,7 +108,6 @@ _show_before() {
   fi
 }
 
-# Muestra lo que produjo la última corrida: nuevas líneas en log + estado de warn/pending/lock
 _show_after() {
   local lines_before="$1"
   [[ $VERBOSE -eq 0 ]] && return
@@ -126,18 +124,16 @@ _show_after() {
   fi
 
   _show_file_content "warn" "$WARN"
-  _show_file_content "pending" "$PENDING"
+  _show_file_content "notify" "$NOTIFY"
   _show_file_content "lock" "$LOCK"
 }
 
-# Resetea el entorno y muestra qué repo se va a usar
 reset_env() {
   local repo_label="$1"
-  rm -f "$LOCK" "$WARN" "$LOG" "$PENDING"
+  rm -f "$LOCK" "$WARN" "$NOTIFY" "$LOG"
   [[ $VERBOSE -eq 1 ]] && echo "${CYAN}  Repo bajo prueba: ${repo_label}${NC}"
 }
 
-# Corre mw-tools-upgrade -y y muestra antes/después en verbose
 run_upgrade() {
   local lines_before=0
   [[ -f "$LOG" ]] && lines_before=$(wc -l < "$LOG")
@@ -198,7 +194,7 @@ fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 3: Repo al día — no se escribe warn ni pending"
+section "TEST 3: Repo al día — no se escribe warn ni notify"
 # ══════════════════════════════════════════════════════════════════════════════
 
 reset_env "uptodate (repo al día, sin updates remotos)"
@@ -206,14 +202,14 @@ WATCHED_DIRS=("$REPO_UPTODATE")
 
 run_upgrade
 if [[ ! -f "$WARN" ]]; then
-  pass "Sin updates: warn no creado (sin ruido innecesario)"
+  pass "Sin updates: warn no creado"
 else
   fail "Sin updates: warn creado innecesariamente — contenido: $(cat $WARN)"
 fi
-if [[ ! -f "$PENDING" ]]; then
-  pass "Sin updates: pending no creado"
+if [[ ! -f "$NOTIFY" ]]; then
+  pass "Sin updates: notify no creado"
 else
-  fail "Sin updates: pending creado innecesariamente — contenido: $(cat $PENDING)"
+  fail "Sin updates: notify creado innecesariamente — contenido: $(cat $NOTIFY)"
 fi
 if grep -q "✅" "$LOG"; then
   pass "Sin updates: log muestra ✅"
@@ -223,22 +219,27 @@ fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 4: Repo con update disponible — se actualiza y warn se escribe"
+section "TEST 4: Repo con update disponible — notify escrito, warn NO escrito"
 # ══════════════════════════════════════════════════════════════════════════════
 
 reset_env "needsupdate (remote tiene un commit nuevo)"
 WATCHED_DIRS=("$REPO_NEEDSUPDATE")
 
 run_upgrade
-if [[ -f "$WARN" ]]; then
-  pass "Con update: warn creado"
-  if grep -q "actualizadas" "$WARN"; then
-    pass "Warn contiene el mensaje de actualización"
+if [[ -f "$NOTIFY" ]]; then
+  pass "Con update: notify creado"
+  if grep -q "actualizadas" "$NOTIFY"; then
+    pass "Notify contiene el mensaje de actualización"
   else
-    fail "Warn existe pero no menciona 'actualizadas': $(cat $WARN)"
+    fail "Notify existe pero no menciona 'actualizadas': $(cat $NOTIFY)"
   fi
 else
-  fail "Con update: warn NO fue creado — el usuario no se entera del update"
+  fail "Con update: notify NO fue creado — el usuario no se entera del update"
+fi
+if [[ ! -f "$WARN" ]] || [[ ! -s "$WARN" ]]; then
+  pass "Con update: warn no escrito (no hay problemas que requieran acción)"
+else
+  fail "Con update: warn escrito innecesariamente — contenido: $(cat $WARN)"
 fi
 if grep -q "⚠️" "$LOG"; then
   pass "Log muestra ⚠️ para el repo con update"
@@ -248,56 +249,69 @@ fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 5: Warn se muestra y se limpia al abrir el siguiente shell"
+section "TEST 5: Notify se muestra una vez y se borra — warn persiste"
 # ══════════════════════════════════════════════════════════════════════════════
 
-echo "  ✔️  mw-tools: actualizadas: /fake/repo" > "$WARN"
-[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Antes:${NC}"; _show_file_content "warn" "$WARN" }
+echo "  ✔️  mw-tools: actualizadas: /fake/repo" > "$NOTIFY"
+echo "  🚩 mw-tools: cambios locales sin commitear en: /fake/repo" > "$WARN"
+[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Antes:${NC}"; _show_file_content "notify" "$NOTIFY"; _show_file_content "warn" "$WARN" }
 
-local output
-output=$(
-  if [[ -f "$WARN" ]]; then
-    cat "$WARN"
-    rm -f "$WARN"
-  fi
-)
+local notify_output warn_output
+notify_output=$(if [[ -f "$NOTIFY" ]]; then cat "$NOTIFY"; rm -f "$NOTIFY"; fi)
+warn_output=$(if [[ -f "$WARN" ]]; then cat "$WARN"; fi)
 
-[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Después:${NC}"; echo "${GRAY}    output mostrado: $output${NC}"; _show_file_content "warn" "$WARN" }
+[[ $VERBOSE -eq 1 ]] && {
+  echo "${CYAN}  Después:${NC}"
+  echo "${GRAY}    notify mostrado: $notify_output${NC}"
+  echo "${GRAY}    warn mostrado:   $warn_output${NC}"
+  _show_file_content "notify" "$NOTIFY"
+  _show_file_content "warn" "$WARN"
+}
 
-if echo "$output" | grep -q "actualizadas"; then
+if echo "$notify_output" | grep -q "actualizadas"; then
+  pass "Notify se muestra al abrir el shell"
+else
+  fail "Notify no se mostró"
+fi
+if [[ ! -f "$NOTIFY" ]]; then
+  pass "Notify se elimina después de mostrarse (one-shot)"
+else
+  fail "Notify no se eliminó"
+fi
+if echo "$warn_output" | grep -q "cambios locales"; then
   pass "Warn se muestra al abrir el shell"
 else
   fail "Warn no se mostró"
 fi
-if [[ ! -f "$WARN" ]]; then
-  pass "Warn se elimina después de mostrarse"
+if [[ -f "$WARN" ]]; then
+  pass "Warn NO se borra al mostrarse (persiste hasta que se resuelva)"
 else
-  fail "Warn no se eliminó"
+  fail "Warn fue borrado — el usuario no lo vería en la próxima terminal"
 fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 6: Repo con cambios locales — pending escrito, warn NO escrito, lock escrito"
+section "TEST 6: Repo con cambios locales — warn escrito, notify NO escrito, lock escrito"
 # ══════════════════════════════════════════════════════════════════════════════
 
 reset_env "localchanges (tiene dirty.txt sin trackear)"
 WATCHED_DIRS=("$REPO_LOCALCHANGES")
 
 run_upgrade
-if [[ -f "$PENDING" ]]; then
-  pass "Cambios locales: pending escrito"
-  if grep -q "cambios locales" "$PENDING"; then
-    pass "Pending menciona los cambios locales"
+if [[ -f "$WARN" ]]; then
+  pass "Cambios locales: warn escrito"
+  if grep -q "cambios locales" "$WARN"; then
+    pass "Warn menciona los cambios locales"
   else
-    fail "Pending no menciona 'cambios locales': $(cat $PENDING)"
+    fail "Warn no menciona 'cambios locales': $(cat $WARN)"
   fi
 else
-  fail "Cambios locales: pending no escrito — el usuario no se entera"
+  fail "Cambios locales: warn no escrito — el usuario no se entera"
 fi
-if [[ ! -f "$WARN" ]] || [[ ! -s "$WARN" ]]; then
-  pass "Cambios locales: warn no escrito (notificación persistente va a pending)"
+if [[ ! -f "$NOTIFY" ]] || [[ ! -s "$NOTIFY" ]]; then
+  pass "Cambios locales: notify no escrito (no hubo actualización)"
 else
-  fail "Cambios locales: warn escrito innecesariamente — contenido: $(cat $WARN)"
+  fail "Cambios locales: notify escrito innecesariamente — contenido: $(cat $NOTIFY)"
 fi
 if [[ -f "$LOCK" && $(cat "$LOCK") == $(date +%Y-%m-%d) ]]; then
   pass "Cambios locales: lock escrito — background no se dispara en cada terminal"
@@ -307,27 +321,27 @@ fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 7: Repo no en main — pending escrito, warn NO escrito, lock escrito"
+section "TEST 7: Repo no en main — warn escrito, notify NO escrito, lock escrito"
 # ══════════════════════════════════════════════════════════════════════════════
 
 reset_env "notmain (en branch feature/test)"
 WATCHED_DIRS=("$REPO_NOTMAIN")
 
 run_upgrade
-if [[ -f "$PENDING" ]]; then
-  pass "Repo en branch no-main: pending escrito"
-  if grep -q "rama no principal" "$PENDING"; then
-    pass "Pending menciona la rama no principal"
+if [[ -f "$WARN" ]]; then
+  pass "Repo en branch no-main: warn escrito"
+  if grep -q "rama no principal" "$WARN"; then
+    pass "Warn menciona la rama no principal"
   else
-    fail "Pending no menciona 'rama no principal': $(cat $PENDING)"
+    fail "Warn no menciona 'rama no principal': $(cat $WARN)"
   fi
 else
-  fail "Repo en branch no-main: pending no escrito"
+  fail "Repo en branch no-main: warn no escrito"
 fi
-if [[ ! -f "$WARN" ]] || [[ ! -s "$WARN" ]]; then
-  pass "Repo en branch no-main: warn no escrito (va a pending)"
+if [[ ! -f "$NOTIFY" ]] || [[ ! -s "$NOTIFY" ]]; then
+  pass "Repo en branch no-main: notify no escrito (no hubo actualización)"
 else
-  fail "Repo en branch no-main: warn escrito innecesariamente"
+  fail "Repo en branch no-main: notify escrito innecesariamente"
 fi
 if [[ -f "$LOCK" && $(cat "$LOCK") == $(date +%Y-%m-%d) ]]; then
   pass "Repo en branch: lock escrito — background no se dispara en cada terminal"
@@ -349,11 +363,11 @@ local force_output
 force_output=$(mw-tools-force-upgrade 2>&1)
 
 [[ $VERBOSE -eq 1 ]] && {
-  echo "${CYAN}  Output de force-upgrade (va a stdout, no a warn ni log):${NC}"
+  echo "${CYAN}  Output de force-upgrade (va a stdout, no a warn/notify/log):${NC}"
   echo "$force_output" | while IFS= read -r line; do echo "${GRAY}    $line${NC}"; done
   echo "${CYAN}  Después:${NC}"
   _show_file_content "warn" "$WARN"
-  _show_file_content "pending" "$PENDING"
+  _show_file_content "notify" "$NOTIFY"
   _show_file_content "lock" "$LOCK"
 }
 
@@ -363,70 +377,34 @@ else
   fail "force-upgrade no corrió el check"
 fi
 if [[ ! -f "$WARN" ]] || [[ ! -s "$WARN" ]]; then
-  pass "force-upgrade: output va a stdout, no al warn"
+  pass "force-upgrade: sin problemas, warn no escrito"
 else
-  fail "force-upgrade: escribió al warn cuando no debería"
+  fail "force-upgrade: warn escrito cuando no debería"
 fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 9: Pending persiste entre aperturas de terminal (no se borra al mostrarse)"
+section "TEST 9: Warn se limpia cuando el check es limpio"
 # ══════════════════════════════════════════════════════════════════════════════
 
-echo "  🚩 mw-tools: cambios locales sin commitear en: /fake/repo" > "$PENDING"
-[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Antes:${NC}"; _show_file_content "pending" "$PENDING" }
-
-# Simula lo que hace el startup block: mostrar pending SIN borrarlo
-local pending_output
-pending_output=$(
-  if [[ -f "$PENDING" ]]; then
-    cat "$PENDING"
-  fi
-)
-
-[[ $VERBOSE -eq 1 ]] && {
-  echo "${CYAN}  Después de mostrar (simula 2 aperturas de terminal):${NC}"
-  echo "${GRAY}    output mostrado: $pending_output${NC}"
-  _show_file_content "pending" "$PENDING"
-}
-
-if echo "$pending_output" | grep -q "cambios locales"; then
-  pass "Pending se muestra en la terminal"
-else
-  fail "Pending no se mostró"
-fi
-if [[ -f "$PENDING" ]]; then
-  pass "Pending NO se borra al mostrarse (persiste para la próxima terminal)"
-else
-  fail "Pending fue borrado — el usuario no lo vería en la próxima terminal"
-fi
-
-
-# ══════════════════════════════════════════════════════════════════════════════
-section "TEST 10: Pending se limpia cuando el check es limpio"
-# ══════════════════════════════════════════════════════════════════════════════
-
-# Arrancamos con un pending de una sesión anterior
-echo "  🚩 mw-tools: cambios locales sin commitear en: /fake/repo" > "$PENDING"
+echo "  🚩 mw-tools: cambios locales sin commitear en: /fake/repo" > "$WARN"
 rm -f "$LOCK"
 WATCHED_DIRS=("$REPO_UPTODATE")
 
-[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Estado inicial: pending existe de sesión anterior${NC}"; _show_file_content "pending" "$PENDING" }
+[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Estado inicial: warn existe de chequeo anterior${NC}"; _show_file_content "warn" "$WARN" }
 
 run_upgrade
 
-if [[ ! -f "$PENDING" ]]; then
-  pass "Check limpio: pending eliminado (problema resuelto)"
+if [[ ! -f "$WARN" ]]; then
+  pass "Check limpio: warn eliminado (problema resuelto)"
 else
-  fail "Check limpio: pending NO eliminado — contenido: $(cat $PENDING)"
+  fail "Check limpio: warn NO eliminado — contenido: $(cat $WARN)"
 fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 11: Race condition — dos shells abren casi simultáneamente"
+section "TEST 10: Race condition — dos shells abren casi simultáneamente"
 # ══════════════════════════════════════════════════════════════════════════════
-# Shell 2 abre antes de que el background de Shell 1 escriba el lock.
-# Ambos backgrounds corren en paralelo. Al menos uno debe actualizar y escribir el warn.
 
 reset_env "needsupdate (con nuevo commit remoto)"
 WATCHED_DIRS=("$REPO_NEEDSUPDATE")
@@ -444,26 +422,26 @@ sleep 0.1
 sleep 3
 [[ $VERBOSE -eq 1 ]] && {
   echo "${CYAN}  Después (ambos BGs terminaron):${NC}"
+  _show_file_content "notify" "$NOTIFY"
   _show_file_content "warn" "$WARN"
-  _show_file_content "pending" "$PENDING"
   _show_file_content "lock" "$LOCK"
   echo "${GRAY}    log:${NC}"
   [[ -f "$LOG" ]] && while IFS= read -r line; do echo "${GRAY}      $line${NC}"; done < "$LOG"
 }
 
-if [[ -f "$WARN" ]]; then
-  pass "Race condition: al menos un BG escribió el warn"
+if [[ -f "$NOTIFY" ]]; then
+  pass "Race condition: al menos un BG escribió el notify"
 else
   if grep -q "actualizadas\|All tools up to date\|✅" "$LOG" 2>/dev/null; then
-    pass "Race condition: repo procesado — si no hay warn es porque el segundo BG vio el lock y el primero ya actualizó"
+    pass "Race condition: repo procesado — el segundo BG vio el lock y el primero ya actualizó"
   else
-    fail "Race condition: warn ausente y sin evidencia de procesamiento"
+    fail "Race condition: notify ausente y sin evidencia de procesamiento"
   fi
 fi
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-section "TEST 12: Log se rota a 500 líneas"
+section "TEST 11: Log se rota a 500 líneas"
 # ══════════════════════════════════════════════════════════════════════════════
 
 reset_env "uptodate"

--- a/test-updates.sh
+++ b/test-updates.sh
@@ -1,0 +1,492 @@
+#!/usr/bin/env zsh
+# Tests para mw-tools-upgrade: flujo de notificaciones y actualización automática.
+# Mockea git con repos locales temporales. No toca repos reales.
+# Uso: zsh test-updates.sh [-v|--verbose]
+
+setopt LOCAL_OPTIONS EXTENDED_GLOB
+
+# ── Flags ──────────────────────────────────────────────────────────────────────
+VERBOSE=0
+for arg in "$@"; do [[ "$arg" == "-v" || "$arg" == "--verbose" ]] && VERBOSE=1; done
+
+# ── Colores ────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'
+GRAY='\033[0;90m'; BOLD='\033[1m'; NC='\033[0m'
+PASS=0; FAIL=0
+
+pass() { echo "  ${GREEN}✔ PASS${NC} $1"; (( PASS++ )) }
+fail() { echo "  ${RED}✘ FAIL${NC} $1"; (( FAIL++ )) }
+section() { echo "\n${YELLOW}${BOLD}$1${NC}" }
+
+# ── Entorno temporal aislado ───────────────────────────────────────────────────
+TMPDIR_TEST=$(mktemp -d)
+export HOME="$TMPDIR_TEST"
+WARN="${HOME}/.mw-tools-upgrade.warn"
+LOCK="${HOME}/.mw-tools-upgrade.lock"
+LOG="${HOME}/.mw-tools-upgrade.log"
+PENDING="${HOME}/.mw-tools-upgrade.pending"
+
+cleanup() { rm -rf "$TMPDIR_TEST" }
+trap cleanup EXIT
+
+# ── Repos fake ────────────────────────────────────────────────────────────────
+REPO_UPTODATE="${TMPDIR_TEST}/fake-repos/uptodate"
+REPO_NEEDSUPDATE="${TMPDIR_TEST}/fake-repos/needsupdate"
+REPO_LOCALCHANGES="${TMPDIR_TEST}/fake-repos/localchanges"
+REPO_NOTMAIN="${TMPDIR_TEST}/fake-repos/notmain"
+BARE_NEEDSUPDATE="${TMPDIR_TEST}/bare-needsupdate.git"
+
+setup_fake_repos() {
+  export GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@test.com"
+  export GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@test.com"
+
+  # uptodate: main, en sync con remote
+  mkdir -p "$REPO_UPTODATE"
+  git -C "$REPO_UPTODATE" init -b main -q
+  git -C "$REPO_UPTODATE" commit --allow-empty -m "init" -q
+  git -C "$REPO_UPTODATE" remote add origin "$REPO_UPTODATE"
+  git -C "$REPO_UPTODATE" fetch -q 2>/dev/null || true
+
+  # needsupdate: main, el remote tiene un commit nuevo que local no tiene
+  mkdir -p "$REPO_NEEDSUPDATE"
+  git -C "$REPO_NEEDSUPDATE" init -b main -q
+  git -C "$REPO_NEEDSUPDATE" commit --allow-empty -m "v1" -q
+  git clone --bare -q "$REPO_NEEDSUPDATE" "$BARE_NEEDSUPDATE"
+  git -C "$REPO_NEEDSUPDATE" remote add origin "$BARE_NEEDSUPDATE"
+  git -C "$REPO_NEEDSUPDATE" fetch -q
+  git -C "$REPO_NEEDSUPDATE" branch --set-upstream-to=origin/main main
+  _push_commit_to_needsupdate "v2"
+
+  # localchanges: main, tiene un archivo sin trackear
+  mkdir -p "$REPO_LOCALCHANGES"
+  git -C "$REPO_LOCALCHANGES" init -b main -q
+  git -C "$REPO_LOCALCHANGES" commit --allow-empty -m "init" -q
+  git -C "$REPO_LOCALCHANGES" remote add origin "$REPO_LOCALCHANGES"
+  echo "dirty" > "${REPO_LOCALCHANGES}/dirty.txt"
+
+  # notmain: en branch feature, no en main/master
+  mkdir -p "$REPO_NOTMAIN"
+  git -C "$REPO_NOTMAIN" init -b feature/test -q
+  git -C "$REPO_NOTMAIN" commit --allow-empty -m "init" -q
+  git -C "$REPO_NOTMAIN" remote add origin "$REPO_NOTMAIN"
+}
+
+# Agrega un commit al remote de needsupdate sin hacer pull local
+_push_commit_to_needsupdate() {
+  local msg="$1"
+  local tmp="${TMPDIR_TEST}/tmp-push"
+  rm -rf "$tmp"
+  git clone --local -q "$BARE_NEEDSUPDATE" "$tmp" 2>/dev/null
+  git -C "$tmp" commit --allow-empty -m "$msg" -q 2>/dev/null
+  git -C "$tmp" push -q origin main 2>/dev/null
+  rm -rf "$tmp"
+  git -C "$REPO_NEEDSUPDATE" fetch -q 2>/dev/null || true
+}
+
+# ── Helpers de verbose ────────────────────────────────────────────────────────
+
+_show_file_content() {
+  local label="$1" file="$2"
+  if [[ -f "$file" && -s "$file" ]]; then
+    echo "${GRAY}    ${label}:${NC}"
+    while IFS= read -r line; do echo "${GRAY}      $line${NC}"; done < "$file"
+  else
+    echo "${GRAY}    ${label}: (no existe)${NC}"
+  fi
+}
+
+# Muestra el estado de lock/warn/pending/log antes de correr
+_show_before() {
+  [[ $VERBOSE -eq 0 ]] && return
+  echo "${CYAN}  Antes:${NC}"
+  _show_file_content "lock" "$LOCK"
+  _show_file_content "warn" "$WARN"
+  _show_file_content "pending" "$PENDING"
+  if [[ -f "$LOG" ]]; then
+    echo "${GRAY}    log:  $(wc -l < $LOG) líneas existentes${NC}"
+  else
+    echo "${GRAY}    log:  (no existe)${NC}"
+  fi
+}
+
+# Muestra lo que produjo la última corrida: nuevas líneas en log + estado de warn/pending/lock
+_show_after() {
+  local lines_before="$1"
+  [[ $VERBOSE -eq 0 ]] && return
+  echo "${CYAN}  Después:${NC}"
+
+  local total=0
+  [[ -f "$LOG" ]] && total=$(wc -l < "$LOG")
+  local new=$(( total - lines_before ))
+  if [[ $new -gt 0 ]]; then
+    echo "${GRAY}    log output:${NC}"
+    tail -$new "$LOG" | while IFS= read -r line; do echo "${GRAY}      $line${NC}"; done
+  else
+    echo "${GRAY}    log output: (ninguno — la función no llegó a correr)${NC}"
+  fi
+
+  _show_file_content "warn" "$WARN"
+  _show_file_content "pending" "$PENDING"
+  _show_file_content "lock" "$LOCK"
+}
+
+# Resetea el entorno y muestra qué repo se va a usar
+reset_env() {
+  local repo_label="$1"
+  rm -f "$LOCK" "$WARN" "$LOG" "$PENDING"
+  [[ $VERBOSE -eq 1 ]] && echo "${CYAN}  Repo bajo prueba: ${repo_label}${NC}"
+}
+
+# Corre mw-tools-upgrade -y y muestra antes/después en verbose
+run_upgrade() {
+  local lines_before=0
+  [[ -f "$LOG" ]] && lines_before=$(wc -l < "$LOG")
+  _show_before
+  echo "${CYAN}  Ejecutando: ${BOLD}mw-tools-upgrade -y${NC}"
+  mw-tools-upgrade -y >> "$LOG" 2>&1
+  _show_after "$lines_before"
+}
+
+# ── Cargar funciones bajo test ────────────────────────────────────────────────
+GIT_UPDATE_CHECK_FILE="$LOCK"
+source "$(dirname $0)/zshrc.mikroways.updates" 2>/dev/null || {
+  echo "ERROR: no se pudo cargar zshrc.mikroways.updates"; exit 1
+}
+
+setup_fake_repos
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 1: Lock file — evita doble ejecución en el mismo día"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "uptodate (repo al día)"
+WATCHED_DIRS=("$REPO_UPTODATE")
+
+[[ $VERBOSE -eq 1 ]] && echo "${CYAN}  Corrida 1 — sin lock, debe correr completo:${NC}"
+run_upgrade
+if [[ -f "$LOCK" && $(cat "$LOCK") == $(date +%Y-%m-%d) ]]; then
+  pass "Primera corrida escribe el lock con la fecha de hoy"
+else
+  fail "Primera corrida no escribió el lock correcto"
+fi
+
+[[ $VERBOSE -eq 1 ]] && echo "${CYAN}  Corrida 2 — lock de hoy ya existe, debe salir sin hacer nada:${NC}"
+local lines_before=$(wc -l < "$LOG")
+run_upgrade
+if [[ $(wc -l < "$LOG") -eq $lines_before ]]; then
+  pass "Segunda corrida con lock de hoy no agrega nada al log"
+else
+  fail "Segunda corrida debería salir por lock, pero escribió al log"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 2: Lock del día anterior — permite nueva corrida"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "uptodate (repo al día)"
+WATCHED_DIRS=("$REPO_UPTODATE")
+date -d yesterday +%Y-%m-%d > "$LOCK"
+
+run_upgrade
+if grep -q "Checking for Mikroways" "$LOG"; then
+  pass "Lock de fecha anterior no bloquea el check"
+else
+  fail "Lock de fecha anterior bloqueó el check incorrectamente"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 3: Repo al día — no se escribe warn ni pending"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "uptodate (repo al día, sin updates remotos)"
+WATCHED_DIRS=("$REPO_UPTODATE")
+
+run_upgrade
+if [[ ! -f "$WARN" ]]; then
+  pass "Sin updates: warn no creado (sin ruido innecesario)"
+else
+  fail "Sin updates: warn creado innecesariamente — contenido: $(cat $WARN)"
+fi
+if [[ ! -f "$PENDING" ]]; then
+  pass "Sin updates: pending no creado"
+else
+  fail "Sin updates: pending creado innecesariamente — contenido: $(cat $PENDING)"
+fi
+if grep -q "✅" "$LOG"; then
+  pass "Sin updates: log muestra ✅"
+else
+  fail "Sin updates: log no muestra ✅"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 4: Repo con update disponible — se actualiza y warn se escribe"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "needsupdate (remote tiene un commit nuevo)"
+WATCHED_DIRS=("$REPO_NEEDSUPDATE")
+
+run_upgrade
+if [[ -f "$WARN" ]]; then
+  pass "Con update: warn creado"
+  if grep -q "actualizadas" "$WARN"; then
+    pass "Warn contiene el mensaje de actualización"
+  else
+    fail "Warn existe pero no menciona 'actualizadas': $(cat $WARN)"
+  fi
+else
+  fail "Con update: warn NO fue creado — el usuario no se entera del update"
+fi
+if grep -q "⚠️" "$LOG"; then
+  pass "Log muestra ⚠️ para el repo con update"
+else
+  fail "Log no muestra ⚠️"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 5: Warn se muestra y se limpia al abrir el siguiente shell"
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "  ✔️  mw-tools: actualizadas: /fake/repo" > "$WARN"
+[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Antes:${NC}"; _show_file_content "warn" "$WARN" }
+
+local output
+output=$(
+  if [[ -f "$WARN" ]]; then
+    cat "$WARN"
+    rm -f "$WARN"
+  fi
+)
+
+[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Después:${NC}"; echo "${GRAY}    output mostrado: $output${NC}"; _show_file_content "warn" "$WARN" }
+
+if echo "$output" | grep -q "actualizadas"; then
+  pass "Warn se muestra al abrir el shell"
+else
+  fail "Warn no se mostró"
+fi
+if [[ ! -f "$WARN" ]]; then
+  pass "Warn se elimina después de mostrarse"
+else
+  fail "Warn no se eliminó"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 6: Repo con cambios locales — pending escrito, warn NO escrito, lock escrito"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "localchanges (tiene dirty.txt sin trackear)"
+WATCHED_DIRS=("$REPO_LOCALCHANGES")
+
+run_upgrade
+if [[ -f "$PENDING" ]]; then
+  pass "Cambios locales: pending escrito"
+  if grep -q "cambios locales" "$PENDING"; then
+    pass "Pending menciona los cambios locales"
+  else
+    fail "Pending no menciona 'cambios locales': $(cat $PENDING)"
+  fi
+else
+  fail "Cambios locales: pending no escrito — el usuario no se entera"
+fi
+if [[ ! -f "$WARN" ]] || [[ ! -s "$WARN" ]]; then
+  pass "Cambios locales: warn no escrito (notificación persistente va a pending)"
+else
+  fail "Cambios locales: warn escrito innecesariamente — contenido: $(cat $WARN)"
+fi
+if [[ -f "$LOCK" && $(cat "$LOCK") == $(date +%Y-%m-%d) ]]; then
+  pass "Cambios locales: lock escrito — background no se dispara en cada terminal"
+else
+  fail "Cambios locales: lock no escrito — background se dispararía en cada terminal"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 7: Repo no en main — pending escrito, warn NO escrito, lock escrito"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "notmain (en branch feature/test)"
+WATCHED_DIRS=("$REPO_NOTMAIN")
+
+run_upgrade
+if [[ -f "$PENDING" ]]; then
+  pass "Repo en branch no-main: pending escrito"
+  if grep -q "rama no principal" "$PENDING"; then
+    pass "Pending menciona la rama no principal"
+  else
+    fail "Pending no menciona 'rama no principal': $(cat $PENDING)"
+  fi
+else
+  fail "Repo en branch no-main: pending no escrito"
+fi
+if [[ ! -f "$WARN" ]] || [[ ! -s "$WARN" ]]; then
+  pass "Repo en branch no-main: warn no escrito (va a pending)"
+else
+  fail "Repo en branch no-main: warn escrito innecesariamente"
+fi
+if [[ -f "$LOCK" && $(cat "$LOCK") == $(date +%Y-%m-%d) ]]; then
+  pass "Repo en branch: lock escrito — background no se dispara en cada terminal"
+else
+  fail "Repo en branch: lock no escrito — background se dispararía en cada terminal"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 8: mw-tools-force-upgrade — ignora lock y output va a stdout"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "uptodate"
+WATCHED_DIRS=("$REPO_UPTODATE")
+echo "$(date +%Y-%m-%d)" > "$LOCK"
+[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Antes:${NC}"; _show_file_content "lock" "$LOCK" }
+
+local force_output
+force_output=$(mw-tools-force-upgrade 2>&1)
+
+[[ $VERBOSE -eq 1 ]] && {
+  echo "${CYAN}  Output de force-upgrade (va a stdout, no a warn ni log):${NC}"
+  echo "$force_output" | while IFS= read -r line; do echo "${GRAY}    $line${NC}"; done
+  echo "${CYAN}  Después:${NC}"
+  _show_file_content "warn" "$WARN"
+  _show_file_content "pending" "$PENDING"
+  _show_file_content "lock" "$LOCK"
+}
+
+if echo "$force_output" | grep -q "Checking for Mikroways"; then
+  pass "force-upgrade corre el check a pesar del lock de hoy"
+else
+  fail "force-upgrade no corrió el check"
+fi
+if [[ ! -f "$WARN" ]] || [[ ! -s "$WARN" ]]; then
+  pass "force-upgrade: output va a stdout, no al warn"
+else
+  fail "force-upgrade: escribió al warn cuando no debería"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 9: Pending persiste entre aperturas de terminal (no se borra al mostrarse)"
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "  🚩 mw-tools: cambios locales sin commitear en: /fake/repo" > "$PENDING"
+[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Antes:${NC}"; _show_file_content "pending" "$PENDING" }
+
+# Simula lo que hace el startup block: mostrar pending SIN borrarlo
+local pending_output
+pending_output=$(
+  if [[ -f "$PENDING" ]]; then
+    cat "$PENDING"
+  fi
+)
+
+[[ $VERBOSE -eq 1 ]] && {
+  echo "${CYAN}  Después de mostrar (simula 2 aperturas de terminal):${NC}"
+  echo "${GRAY}    output mostrado: $pending_output${NC}"
+  _show_file_content "pending" "$PENDING"
+}
+
+if echo "$pending_output" | grep -q "cambios locales"; then
+  pass "Pending se muestra en la terminal"
+else
+  fail "Pending no se mostró"
+fi
+if [[ -f "$PENDING" ]]; then
+  pass "Pending NO se borra al mostrarse (persiste para la próxima terminal)"
+else
+  fail "Pending fue borrado — el usuario no lo vería en la próxima terminal"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 10: Pending se limpia cuando el check es limpio"
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Arrancamos con un pending de una sesión anterior
+echo "  🚩 mw-tools: cambios locales sin commitear en: /fake/repo" > "$PENDING"
+rm -f "$LOCK"
+WATCHED_DIRS=("$REPO_UPTODATE")
+
+[[ $VERBOSE -eq 1 ]] && { echo "${CYAN}  Estado inicial: pending existe de sesión anterior${NC}"; _show_file_content "pending" "$PENDING" }
+
+run_upgrade
+
+if [[ ! -f "$PENDING" ]]; then
+  pass "Check limpio: pending eliminado (problema resuelto)"
+else
+  fail "Check limpio: pending NO eliminado — contenido: $(cat $PENDING)"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 11: Race condition — dos shells abren casi simultáneamente"
+# ══════════════════════════════════════════════════════════════════════════════
+# Shell 2 abre antes de que el background de Shell 1 escriba el lock.
+# Ambos backgrounds corren en paralelo. Al menos uno debe actualizar y escribir el warn.
+
+reset_env "needsupdate (con nuevo commit remoto)"
+WATCHED_DIRS=("$REPO_NEEDSUPDATE")
+_push_commit_to_needsupdate "v3"
+
+[[ $VERBOSE -eq 1 ]] && echo "${CYAN}  BG1 arranca con 0.4s de delay (simula fetch lento)${NC}"
+{ sleep 0.4; GIT_UPDATE_CHECK_FILE="$LOCK"; WATCHED_DIRS=("$REPO_NEEDSUPDATE")
+  mw-tools-upgrade -y >> "$LOG" 2>&1 } &!
+
+sleep 0.1
+[[ $VERBOSE -eq 1 ]] && echo "${CYAN}  BG2 arranca antes de que BG1 escriba el lock${NC}"
+{ GIT_UPDATE_CHECK_FILE="$LOCK"; WATCHED_DIRS=("$REPO_NEEDSUPDATE")
+  mw-tools-upgrade -y >> "$LOG" 2>&1 } &!
+
+sleep 3
+[[ $VERBOSE -eq 1 ]] && {
+  echo "${CYAN}  Después (ambos BGs terminaron):${NC}"
+  _show_file_content "warn" "$WARN"
+  _show_file_content "pending" "$PENDING"
+  _show_file_content "lock" "$LOCK"
+  echo "${GRAY}    log:${NC}"
+  [[ -f "$LOG" ]] && while IFS= read -r line; do echo "${GRAY}      $line${NC}"; done < "$LOG"
+}
+
+if [[ -f "$WARN" ]]; then
+  pass "Race condition: al menos un BG escribió el warn"
+else
+  if grep -q "actualizadas\|All tools up to date\|✅" "$LOG" 2>/dev/null; then
+    pass "Race condition: repo procesado — si no hay warn es porque el segundo BG vio el lock y el primero ya actualizó"
+  else
+    fail "Race condition: warn ausente y sin evidencia de procesamiento"
+  fi
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 12: Log se rota a 500 líneas"
+# ══════════════════════════════════════════════════════════════════════════════
+
+reset_env "uptodate"
+WATCHED_DIRS=("$REPO_UPTODATE")
+python3 -c "print('\n'.join(['line ' + str(i) for i in range(600)]))" > "$LOG"
+[[ $VERBOSE -eq 1 ]] && echo "${CYAN}  Log pre-existente: 600 líneas${NC}"
+
+{
+  [[ -f "$LOG" ]] && tail -500 "$LOG" > "${LOG}.tmp" && mv "${LOG}.tmp" "$LOG"
+  mw-tools-upgrade -y >> "$LOG" 2>&1
+} 2>/dev/null
+
+local lines=$(wc -l < "$LOG")
+[[ $VERBOSE -eq 1 ]] && echo "${CYAN}  Líneas en log después de rotar y correr: $lines${NC}"
+if [[ $lines -le 520 ]]; then
+  pass "Log rotado correctamente: $lines líneas (límite 500 + output del run)"
+else
+  fail "Log no rotado: $lines líneas (debería ser ≤520)"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+echo "\n${BOLD}$(printf '─%.0s' {1..50})${NC}"
+echo "Resultados: ${GREEN}${BOLD}${PASS} PASS${NC}  ${RED}${BOLD}${FAIL} FAIL${NC}"
+echo "${BOLD}$(printf '─%.0s' {1..50})${NC}"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -7,8 +7,10 @@ MW_POST_UPDATE_SCRIPTS=(script/install install.sh)
 
 # Last check timestamp file
 GIT_UPDATE_CHECK_FILE="${HOME}/.mw-tools-upgrade.lock"
-# Problemas pendientes (se muestra en cada terminal hasta que se resuelvan)
-MW_PENDING_FILE="${HOME}/.mw-tools-upgrade.pending"
+# Problemas que requieren acción (persiste en cada terminal hasta que se resuelvan)
+MW_WARN_FILE="${HOME}/.mw-tools-upgrade.warn"
+# Notificaciones de una sola vez (repos actualizados)
+MW_NOTIFY_FILE="${HOME}/.mw-tools-upgrade.notify"
 
 function mw-tools-force-upgrade() {
   echo "Forzando chequeo (ignorando lock diario)..."
@@ -180,7 +182,7 @@ function mw-tools-upgrade() {
       done
       echo
       [[ "${#REPOS_UPDATED[@]}" -ne 0 ]] && echo "  ✔️  Mikroways tools updated: ${(j:, :)REPOS_UPDATED}"
-      [[ "${#REPOS_UPDATED[@]}" -ne 0 && $auto_yes -eq 1 ]] && echo "  ✔️  mw-tools: actualizadas: ${(j:, :)REPOS_UPDATED}" >> "${HOME}/.mw-tools-upgrade.warn"
+      [[ "${#REPOS_UPDATED[@]}" -ne 0 && $auto_yes -eq 1 ]] && echo "  ✔️  mw-tools: actualizadas: ${(j:, :)REPOS_UPDATED}" >> "$MW_NOTIFY_FILE"
       [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 ]] && echo "  ❌ Falló el pull de: ${(j:, :)REPOS_PULL_FAILED}"
     else
       echo "  ❌ Omit updates for Mikroways tools"
@@ -190,30 +192,30 @@ function mw-tools-upgrade() {
   # Siempre escribir el lock para no disparar background en cada terminal
   echo "$today" > "$GIT_UPDATE_CHECK_FILE"
 
-  # Actualizar archivo de problemas pendientes (se muestra en cada terminal hasta que se resuelvan)
-  local pending_msgs=()
-  [[ "${#REPOS_NOT_ON_MAIN[@]}" -ne 0 ]] && pending_msgs+=("  📢 mw-tools: repos en rama no principal: ${(j:, :)REPOS_NOT_ON_MAIN}")
-  [[ "${#REPOS_WITH_LOCAL_UPDATES[@]}" -ne 0 ]] && pending_msgs+=("  🚩 mw-tools: cambios locales sin commitear en: ${(j:, :)REPOS_WITH_LOCAL_UPDATES}")
-  [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]] && pending_msgs+=("  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}")
-  [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 ]] && pending_msgs+=("  ❌ mw-tools: falló el pull de: ${(j:, :)REPOS_PULL_FAILED}")
+  # Actualizar .warn con problemas que requieren acción (persiste hasta que se resuelvan)
+  local warn_msgs=()
+  [[ "${#REPOS_NOT_ON_MAIN[@]}" -ne 0 ]] && warn_msgs+=("  📢 mw-tools: repos en rama no principal: ${(j:, :)REPOS_NOT_ON_MAIN}")
+  [[ "${#REPOS_WITH_LOCAL_UPDATES[@]}" -ne 0 ]] && warn_msgs+=("  🚩 mw-tools: cambios locales sin commitear en: ${(j:, :)REPOS_WITH_LOCAL_UPDATES}")
+  [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]] && warn_msgs+=("  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}")
+  [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 ]] && warn_msgs+=("  ❌ mw-tools: falló el pull de: ${(j:, :)REPOS_PULL_FAILED}")
 
-  if [[ "${#pending_msgs[@]}" -ne 0 ]]; then
-    printf '%s\n' "${pending_msgs[@]}" > "$MW_PENDING_FILE"
+  if [[ "${#warn_msgs[@]}" -ne 0 ]]; then
+    printf '%s\n' "${warn_msgs[@]}" > "$MW_WARN_FILE"
   else
-    rm -f "$MW_PENDING_FILE"
+    rm -f "$MW_WARN_FILE"
   fi
 }
 
 
 
-# Mostrar problemas persistentes (se repite en cada terminal hasta que se resuelvan)
-if [[ -f "$MW_PENDING_FILE" ]]; then
-  cat "$MW_PENDING_FILE"
+# Mostrar problemas que requieren acción (persiste en cada terminal hasta que se resuelvan)
+if [[ -f "$MW_WARN_FILE" ]]; then
+  cat "$MW_WARN_FILE"
 fi
 # Mostrar notificaciones de una sola vez (ej: repos actualizados)
-if [[ -f "${HOME}/.mw-tools-upgrade.warn" ]]; then
-  cat "${HOME}/.mw-tools-upgrade.warn"
-  rm -f "${HOME}/.mw-tools-upgrade.warn"
+if [[ -f "$MW_NOTIFY_FILE" ]]; then
+  cat "$MW_NOTIFY_FILE"
+  rm -f "$MW_NOTIFY_FILE"
 fi
 if [[ ! -f "$GIT_UPDATE_CHECK_FILE" || $(cat "$GIT_UPDATE_CHECK_FILE" 2>/dev/null) != "$(date +%Y-%m-%d)" ]]; then
   echo "  🔄 mw-tools: chequeando actualizaciones en background..."

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -7,6 +7,8 @@ MW_POST_UPDATE_SCRIPTS=(script/install install.sh)
 
 # Last check timestamp file
 GIT_UPDATE_CHECK_FILE="${HOME}/.mw-tools-upgrade.lock"
+# Problemas pendientes (se muestra en cada terminal hasta que se resuelvan)
+MW_PENDING_FILE="${HOME}/.mw-tools-upgrade.pending"
 
 function mw-tools-force-upgrade() {
   echo "Forzando chequeo (ignorando lock diario)..."
@@ -41,7 +43,6 @@ function mw-tools-upgrade() {
   printf '%0.s=' {1..80}; echo
   echo "Checking for Mikroways tools updates...."
   printf '%0.s=' {1..80}; echo
-  echo "$today" > "$GIT_UPDATE_CHECK_FILE"
 
   # Clasificar repos por rama
   for repo_dir in "${WATCHED_DIRS[@]}"; do
@@ -53,9 +54,6 @@ function mw-tools-upgrade() {
       REPOS_MAIN+=( $repo_dir )
     fi
   done
-  if [[ "${#REPOS_NOT_ON_MAIN[@]}" -ne 0 ]]; then
-    [[ $auto_yes -eq 1 ]] && echo "  📢 mw-tools: repos en rama no principal: ${(j:, :)REPOS_NOT_ON_MAIN}" >> "${HOME}/.mw-tools-upgrade.warn"
-  fi
 
   # Verificar cambios locales (solo repos en rama principal)
   for repo_dir in "${REPOS_MAIN[@]}"; do
@@ -69,7 +67,6 @@ function mw-tools-upgrade() {
   done
   if [[ "${#REPOS_WITH_LOCAL_UPDATES[@]}" -ne 0 ]]; then
     echo "  ⚠️  Repos with local changes (skipped): ${(j:, :)REPOS_WITH_LOCAL_UPDATES}"
-    [[ $auto_yes -eq 1 ]] && echo "  🚩 mw-tools: cambios locales sin commitear en: ${(j:, :)REPOS_WITH_LOCAL_UPDATES}" >> "${HOME}/.mw-tools-upgrade.warn"
     REPOS_MAIN=("${(@)REPOS_MAIN:|REPOS_WITH_LOCAL_UPDATES_PATHS}")
   fi
 
@@ -146,9 +143,6 @@ function mw-tools-upgrade() {
   done
   rm -rf $tmpdir
 
-  if [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]]; then
-    [[ $auto_yes -eq 1 ]] && echo "  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}" >> "${HOME}/.mw-tools-upgrade.warn"
-  fi
   if [[ "${#REPOS_TO_UPDATE[@]}" -eq 0 && "${#REPOS_WITH_FETCH_ERROR[@]}" -eq 0 ]]; then
     printf '%0.s-' {1..80}; echo
     echo "✔️  All tools up to date"
@@ -188,19 +182,41 @@ function mw-tools-upgrade() {
       [[ "${#REPOS_UPDATED[@]}" -ne 0 ]] && echo "  ✔️  Mikroways tools updated: ${(j:, :)REPOS_UPDATED}"
       [[ "${#REPOS_UPDATED[@]}" -ne 0 && $auto_yes -eq 1 ]] && echo "  ✔️  mw-tools: actualizadas: ${(j:, :)REPOS_UPDATED}" >> "${HOME}/.mw-tools-upgrade.warn"
       [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 ]] && echo "  ❌ Falló el pull de: ${(j:, :)REPOS_PULL_FAILED}"
-      [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 && $auto_yes -eq 1 ]] && echo "  ❌ mw-tools: falló el pull de: ${(j:, :)REPOS_PULL_FAILED}" >> "${HOME}/.mw-tools-upgrade.warn"
     else
       echo "  ❌ Omit updates for Mikroways tools"
     fi
+  fi
+
+  # Siempre escribir el lock para no disparar background en cada terminal
+  echo "$today" > "$GIT_UPDATE_CHECK_FILE"
+
+  # Actualizar archivo de problemas pendientes (se muestra en cada terminal hasta que se resuelvan)
+  local pending_msgs=()
+  [[ "${#REPOS_NOT_ON_MAIN[@]}" -ne 0 ]] && pending_msgs+=("  📢 mw-tools: repos en rama no principal: ${(j:, :)REPOS_NOT_ON_MAIN}")
+  [[ "${#REPOS_WITH_LOCAL_UPDATES[@]}" -ne 0 ]] && pending_msgs+=("  🚩 mw-tools: cambios locales sin commitear en: ${(j:, :)REPOS_WITH_LOCAL_UPDATES}")
+  [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]] && pending_msgs+=("  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}")
+  [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 ]] && pending_msgs+=("  ❌ mw-tools: falló el pull de: ${(j:, :)REPOS_PULL_FAILED}")
+
+  if [[ "${#pending_msgs[@]}" -ne 0 ]]; then
+    printf '%s\n' "${pending_msgs[@]}" > "$MW_PENDING_FILE"
+  else
+    rm -f "$MW_PENDING_FILE"
   fi
 }
 
 
 
-# Mostrar warnings del check anterior y lanzar nuevo check en background
+# Mostrar problemas persistentes (se repite en cada terminal hasta que se resuelvan)
+if [[ -f "$MW_PENDING_FILE" ]]; then
+  cat "$MW_PENDING_FILE"
+fi
+# Mostrar notificaciones de una sola vez (ej: repos actualizados)
 if [[ -f "${HOME}/.mw-tools-upgrade.warn" ]]; then
   cat "${HOME}/.mw-tools-upgrade.warn"
   rm -f "${HOME}/.mw-tools-upgrade.warn"
+fi
+if [[ ! -f "$GIT_UPDATE_CHECK_FILE" || $(cat "$GIT_UPDATE_CHECK_FILE" 2>/dev/null) != "$(date +%Y-%m-%d)" ]]; then
+  echo "  🔄 mw-tools: chequeando actualizaciones en background..."
 fi
 {
   local log="${HOME}/.mw-tools-upgrade.log"


### PR DESCRIPTION
## Resumen

Refactoriza el sistema de notificaciones de updates y agrega suite de tests.

## Commits

### `3c3813f` — Agrega sistema de pending para notificaciones persistentes

- **Lock siempre se escribe** al terminar el check, evitando que el background se dispare en cada terminal nueva
- Introduce dos archivos con semántica diferente:
  - `.mw-tools-upgrade.pending`: problemas que requieren acción (cambios locales, rama incorrecta, fetch error) — persiste en cada terminal hasta resolverlos
  - `.mw-tools-upgrade.warn`: notificación de una sola vez al actualizar repos — se muestra y se elimina
- Pending se limpia automáticamente cuando el próximo check es limpio
- Agrega `test-updates.sh` con 12 tests y 26 assertions

### `f30609b` — Renombra .pending→.warn y .warn→.notify

- Clarifica la semántica con nombres más intuitivos:
  - `.warn` (antes `.pending`): problemas persistentes
  - `.notify` (antes `.warn`): notificaciones de una sola vez
- Reutiliza el nombre `.warn` que ya existe en las máquinas de los usuarios para evitar archivos huérfanos
- Actualiza tests para incorporar este cambio

## Tests

Cubren: lock diario, lock vencido, repos al día, repos con updates, cambios locales, branch no-main, force-upgrade, persistencia de warn, one-shot de notify, race condition y rotación de log.