### PR TITLE
Mejoras en configuración de git y script de instalación

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,29 +17,6 @@ utilizados desde la consola como por ejemplo:
 * git
 * tmux
 
-## Pasos manuales requeridos
-
-### Configuración personal de git
-
-El archivo `gitconfig.local` contiene datos personales (nombre, email) y **no
-forma parte del repositorio**. Debe crearse directamente en el home:
-
-```bash
-cp ~/.mikroways/dotfiles/gitconfig.local.sample ~/.gitconfig.local
-```
-
-Luego editarlo con los datos reales:
-
-```ini
-[user]
-  name = Juan Perez
-  email = juan.perez@mikroways.net
-```
-
-El `gitconfig` del repo lo incluye automáticamente vía `[include]`, por lo que
-cualquier valor definido en `~/.gitconfig.local` sobreescribe la configuración
-compartida sin generar cambios en el repositorio.
-
 ## Cómo usar este repositorio
 
 La idea es que cada integrante de Mikroways utilice este repositorio como punto
@@ -61,6 +38,74 @@ Las personalizaciones se pueden hacer en cascada de la siguiente forma:
    desea sobreescribir
 1. Respecto a los bundles de antigen, es posible aplicar personalizaciones con:
   `.zshrc.mikroways.antigen.bundles` y `.zshrc.user.antigen.bundles`
+
+#### Configuración personal de git
+
+El archivo `gitconfig.local` contiene datos personales (nombre, email) y **no
+forma parte del repositorio**. Debe crearse directamente en el home:
+
+```bash
+cp ~/.mikroways/dotfiles/gitconfig.local.sample ~/.gitconfig.local
+```
+
+Luego editarlo con los datos reales:
+
+```ini
+[user]
+  name = Juan Perez
+  email = juan.perez@mikroways.net
+```
+
+El `gitconfig` del repo lo incluye automáticamente vía `[include]`, por lo que
+cualquier valor definido en `~/.gitconfig.local` sobreescribe la configuración
+compartida sin generar cambios en el repositorio.
+
+##### Configuración por contexto opcional
+
+Si manejás repos con identidades distintas (por ejemplo, repos personales con
+un email distinto al de Mikroways), podés usar `includeIf` en
+`~/.gitconfig.local` para aplicar config adicional según el contexto.
+
+Cada archivo referenciado contiene solo los valores que difieren del default:
+
+```ini
+[user]
+  email = juan@personal.com
+```
+
+Hay dos enfoques:
+
+* **Por carpeta (recomendado)**: si tenés una estructura de carpetas clara,
+  por ejemplo `~/personal/` para repos personales, podés usar `gitdir` para
+  aplicar la config a cualquier repo ubicado dentro de esa carpeta:
+
+   ```ini
+   [includeIf "gitdir:~/personal/"]
+     path = ~/.gitconfig.personal
+   ```
+
+* **Por URL del remote**
+
+   Aplica la config a cualquier repo cuyo remote
+   coincida con el patrón, sin importar dónde esté clonado. Hay que agregar
+   un bloque por cada combinación de host y protocolo (SSH y HTTPS):
+
+   ```ini
+   # Requiere git >= 2.36.
+   # Organización en GitHub (SSH y HTTPS)
+   [includeIf "hasconfig:remote.*.url:git@github.com:mi-org/**"]
+     path = ~/.gitconfig.mi-org
+   [includeIf "hasconfig:remote.*.url:https://github.com/mi-org/**"]
+     path = ~/.gitconfig.mi-org
+
+   # GitLab privado — en SSH el separador entre host y ruta es ":" en lugar de "/"
+   [includeIf "hasconfig:remote.*.url:git@gitlab.empresa.com:**"]
+     path = ~/.gitconfig.empresa
+   [includeIf "hasconfig:remote.*.url:https://gitlab.empresa.com/**"]
+     path = ~/.gitconfig.empresa
+   ```
+
+El [`gitconfig.local.sample`](gitconfig.local.sample) incluye ambos ejemplos comentados.
 
 ## Integración con herramientas propias de mikroways
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ utilizados desde la consola como por ejemplo:
 * git
 * tmux
 
+> **Nota**: si ya tenés archivos de configuración en tu home (`.gitconfig`,
+> `.zshrc`, etc.), el instalador los respalda automáticamente en
+> `./backup/` antes de reemplazarlos con symlinks. Revisa el
+> backup y migra manualmente lo que necesites (ver sección
+> [Personalizaciones de Mikroways y Usuario](#personalizaciones-de-mikroways-y-usuario)).
+
 ## Cómo usar este repositorio
 
 La idea es que cada integrante de Mikroways utilice este repositorio como punto
@@ -25,6 +31,12 @@ configuraciones y proponiéndolas al repositorio raíz, compartiendo experiencia
 que nos hagan más eficientes en el día a día.
 Para ello se puede forkear este repositorio y cualquier contribución realizarla
 como un Pull Request.
+
+> **Atención**: el script `script/install` crea un symlink en el home del
+> usuario para cada archivo del repo que no esté excluido explícitamente. Si
+> agregás un archivo nuevo, revisá [`script/install`](script/install) para
+> verificar que matchee alguna exclusión, o agregá una nueva. De lo contrario
+> **se va a copiar al home de todos los usuarios**.
 
 ### Personalizaciones de Mikroways y Usuario
 

--- a/gitconfig.local.sample
+++ b/gitconfig.local.sample
@@ -1,3 +1,32 @@
 [user]
   name = Juan Perez
   email = juan.perez@mikroways.net
+
+# Configuración por contexto (opcional)
+#
+# Permite usar una identidad distinta (email, firma) para ciertos repos.
+# Caso típico: repos personales con un email distinto al de Mikroways.
+#
+# --- Opción 1: por carpeta (recomendado, funciona con cualquier versión de git)
+#
+# [includeIf "gitdir:~/personal/"]
+#   path = ~/.gitconfig.personal
+#
+# --- Opción 2: por URL del remote (requiere git >= 2.36)
+#
+# Organización en GitHub (SSH y HTTPS):
+# [includeIf "hasconfig:remote.*.url:git@github.com:mi-org/**"]
+#   path = ~/.gitconfig.mi-org
+# [includeIf "hasconfig:remote.*.url:https://github.com/mi-org/**"]
+#   path = ~/.gitconfig.mi-org
+#
+# GitLab privado — en SSH el separador entre host y ruta es ":" en lugar de "/":
+# [includeIf "hasconfig:remote.*.url:git@gitlab.empresa.com:**"]
+#   path = ~/.gitconfig.empresa
+# [includeIf "hasconfig:remote.*.url:https://gitlab.empresa.com/**"]
+#   path = ~/.gitconfig.empresa
+#
+# En cada archivo referenciado solo ponés lo que difiere del default:
+#
+# [user]
+#   email = juan.perez@personal.com

--- a/script/install
+++ b/script/install
@@ -9,9 +9,14 @@ mkdir -p "$BACKUP_DIR"
 
 cd "$DIR"
 for file in *; do
+  # ATENCION: cualquier archivo que no matchee esta exclusion se va a
+  # copiar como symlink al home de todos los usuarios al correr el install.
   [[ "$file" =~ (ssh|script|backup|README.*md|.*sample$|.*\.sh$) ]] && continue
-  [ -e "$HOME/.$file" ] && [ ! -L "$HOME/.$file" ] && \
+  if [ -e "$HOME/.$file" ] && [ ! -L "$HOME/.$file" ]; then
     mv "$HOME/.$file" "$BACKUP_DIR"
+    echo "⚠️  ~/.${file} existente respaldado en $BACKUP_DIR/$file"
+    echo "    Revisa el backup y migra lo que necesites manualmente."
+  fi
   ln -fs "$DIR/$file" "$HOME/.$file"
 done
 


### PR DESCRIPTION
## Resumen

### `92ea72d` — Documenta configuración de git por contexto con includeIf

- Agrega sección en el README explicando cómo usar identidades distintas según el contexto (repos personales vs. trabajo)
- Dos enfoques documentados: por carpeta (`gitdir`, recomendado) y por URL del remote (`hasconfig`, requiere git >= 2.36)
- Ejemplos para organización en GitHub y GitLab privado
- Actualiza `gitconfig.local.sample` con los mismos ejemplos comentados

### `173c9ef` — Mejora el script de install: avisa al respaldar archivos y documenta exclusiones

- El install ahora muestra un mensaje cuando respalda un archivo existente del home
- Agrega comentario en el regex de exclusión advirtiendo que cualquier archivo no excluido se copia al home de todos los usuarios
- Documenta este comportamiento en el README con una nota de atención para contribuidores