### PR TITLE
Fix: claves SSH con passphrase cuelgan/crashean el auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ notifica al inicio de la **próxima** sesión de terminal.
   `master` se reportan como advertencia pero no se actualizan automáticamente.
 * **Sin cambios locales**: si un repositorio tiene cambios sin commitear, se
   aborta la actualización y se avisa.
+* **Claves SSH con passphrase**: el chequeo corre en background sin terminal,
+  por lo que nunca pide la passphrase de una clave SSH (evita que el proceso
+  quede colgado o rompa la sesión). Si tu clave la requiere, tenés que tenerla
+  ya cargada en el agente (`ssh-add`) o configurada para desbloquearse sola al
+  iniciar sesión; de lo contrario, el repo correspondiente va a quedar
+  reportado en `.warn` hasta que la cargues. Si corrés `mw-tools-upgrade`
+  manualmente y la autenticación falla, te ofrece correr `ssh-add` y reintentar
+  en el momento.
 * **Notificaciones diferidas**: los avisos se muestran al abrir la siguiente
   terminal, no mientras el chequeo corre en background. Hay dos tipos:
   * **Problemas** (`.warn`): cambios locales sin commitear, repo en rama no

--- a/script/install
+++ b/script/install
@@ -30,9 +30,7 @@ for i in es.latin1.spl es.latin1.sug es.utf-8.spl es.utf-8.sug; do
   curl -sfLo "$HOME/.vim/spell/$i" --create-dirs \
     "https://ftp.nluug.nl/pub/vim/runtime/spell/$i"
 done
-# Install vim plugins (solo si hay una terminal interactiva; si este script
-# corre en background -p.ej. desde mw-tools-upgrade- vim no puede pedir
-# input y termina con error)
+# Install vim plugins (solo con terminal interactiva; en background vim falla)
 if [ -t 0 ] && [ -t 1 ]; then
   vim +PlugClean +PlugUpdate +qall
 else

--- a/script/install
+++ b/script/install
@@ -30,5 +30,11 @@ for i in es.latin1.spl es.latin1.sug es.utf-8.spl es.utf-8.sug; do
   curl -sfLo "$HOME/.vim/spell/$i" --create-dirs \
     "https://ftp.nluug.nl/pub/vim/runtime/spell/$i"
 done
-# Install vim plugins
-vim +PlugClean +PlugUpdate +qall
+# Install vim plugins (solo si hay una terminal interactiva; si este script
+# corre en background -p.ej. desde mw-tools-upgrade- vim no puede pedir
+# input y termina con error)
+if [ -t 0 ] && [ -t 1 ]; then
+  vim +PlugClean +PlugUpdate +qall
+else
+  echo "  ⚠️  Sin terminal interactiva: se omite la actualización de plugins de vim (correr 'vim +PlugClean +PlugUpdate +qall' manualmente)."
+fi

--- a/test-updates.sh
+++ b/test-updates.sh
@@ -34,6 +34,7 @@ REPO_UPTODATE="${TMPDIR_TEST}/fake-repos/uptodate"
 REPO_NEEDSUPDATE="${TMPDIR_TEST}/fake-repos/needsupdate"
 REPO_LOCALCHANGES="${TMPDIR_TEST}/fake-repos/localchanges"
 REPO_NOTMAIN="${TMPDIR_TEST}/fake-repos/notmain"
+REPO_SSHAUTH="${TMPDIR_TEST}/fake-repos/sshauth"
 BARE_NEEDSUPDATE="${TMPDIR_TEST}/bare-needsupdate.git"
 
 setup_fake_repos() {
@@ -69,6 +70,13 @@ setup_fake_repos() {
   git -C "$REPO_NOTMAIN" init -b feature/test -q
   git -C "$REPO_NOTMAIN" commit --allow-empty -m "init" -q
   git -C "$REPO_NOTMAIN" remote add origin "$REPO_NOTMAIN"
+
+  # sshauth: remote por ssh con una clave que requeriría passphrase
+  # (ver fake "ssh" en TEST 12)
+  mkdir -p "$REPO_SSHAUTH"
+  git -C "$REPO_SSHAUTH" init -b main -q
+  git -C "$REPO_SSHAUTH" commit --allow-empty -m "init" -q
+  git -C "$REPO_SSHAUTH" remote add origin "git@fakehost-unreachable:mikroways/repo.git"
 }
 
 # Agrega un commit al remote de needsupdate sin hacer pull local
@@ -460,6 +468,99 @@ if [[ $lines -le 520 ]]; then
   pass "Log rotado correctamente: $lines líneas (límite 500 + output del run)"
 else
   fail "Log no rotado: $lines líneas (debería ser ≤520)"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 12: Clave SSH con passphrase — no se cuelga pidiéndola en background"
+# ══════════════════════════════════════════════════════════════════════════════
+# Reproduce el bug reportado: si la clave necesita passphrase y no hay
+# terminal/agente disponible, ssh quedaría esperando input para siempre
+# (o disparando un askpash gráfico que puede crashear). mw-tools-upgrade
+# debe forzar BatchMode=yes para que git/ssh fallen rápido en vez de pedir
+# la passphrase, y reportar el error como un .warn con un hint de ssh-add.
+
+reset_env "sshauth (remote ssh, simula clave bloqueada con passphrase)"
+WATCHED_DIRS=("$REPO_SSHAUTH")
+
+# ssh fake: si recibe BatchMode=yes falla rápido (lo esperable); si no lo
+# recibe, simula quedarse esperando la passphrase (lo que rompía antes).
+mkdir -p "$TMPDIR_TEST/fakebin"
+cat > "$TMPDIR_TEST/fakebin/ssh" <<'FAKESSH'
+#!/bin/sh
+batch=0
+for a in "$@"; do
+  case "$a" in
+    *BatchMode=yes*) batch=1 ;;
+  esac
+done
+if [ "$batch" -eq 1 ]; then
+  echo "git@fakehost-unreachable: Permission denied (publickey)." >&2
+  exit 255
+else
+  sleep 5
+  exit 1
+fi
+FAKESSH
+chmod +x "$TMPDIR_TEST/fakebin/ssh"
+
+local OLDPATH="$PATH"
+export PATH="$TMPDIR_TEST/fakebin:$PATH"
+
+local start_ts=$(date +%s)
+run_upgrade
+local elapsed=$(( $(date +%s) - start_ts ))
+
+export PATH="$OLDPATH"
+
+if [[ $elapsed -le 3 ]]; then
+  pass "No se cuelga esperando la passphrase (terminó en ${elapsed}s, no en >5s)"
+else
+  fail "Se colgó esperando la passphrase (tardó ${elapsed}s) — falta BatchMode=yes"
+fi
+if grep -q "Permission denied" "$LOG"; then
+  pass "El error de auth se reporta en el log"
+else
+  fail "El error de auth no aparece en el log:\n$(cat $LOG)"
+fi
+if [[ -f "$WARN" ]] && grep -q "ssh-add" "$WARN"; then
+  pass "El warn sugiere 'ssh-add' para cargar la clave en el agente"
+else
+  fail "El warn no sugiere ssh-add: $(cat $WARN 2>/dev/null)"
+fi
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+section "TEST 13: Error de fetch NO-auth — el warn NO sugiere ssh-add"
+# ══════════════════════════════════════════════════════════════════════════════
+# Complemento del TEST 12: si el fetch falla por algo que no es autenticación
+# (p.ej. el host no resuelve), el hint de ssh-add no debe aparecer.
+
+reset_env "sshauth (remote ssh, simula host inalcanzable)"
+WATCHED_DIRS=("$REPO_SSHAUTH")
+
+# ssh fake: siempre falla con un error que NO es de auth.
+cat > "$TMPDIR_TEST/fakebin/ssh" <<'FAKESSH'
+#!/bin/sh
+echo "ssh: Could not resolve hostname fakehost-unreachable: Name or service not known" >&2
+exit 255
+FAKESSH
+chmod +x "$TMPDIR_TEST/fakebin/ssh"
+
+OLDPATH="$PATH"
+export PATH="$TMPDIR_TEST/fakebin:$PATH"
+run_upgrade
+export PATH="$OLDPATH"
+
+if [[ -f "$WARN" ]] && grep -q "error al hacer fetch" "$WARN"; then
+  pass "El error de fetch se reporta en el warn"
+else
+  fail "El error de fetch no aparece en el warn: $(cat $WARN 2>/dev/null)"
+fi
+if [[ -f "$WARN" ]] && grep -q "ssh-add" "$WARN"; then
+  fail "El warn sugiere ssh-add ante un error que no es de auth: $(cat $WARN)"
+else
+  pass "El warn NO sugiere ssh-add (el error no era de autenticación)"
 fi
 
 

--- a/test-updates.sh
+++ b/test-updates.sh
@@ -486,15 +486,17 @@ WATCHED_DIRS=("$REPO_SSHAUTH")
 # ssh fake: si recibe BatchMode=yes falla rápido (lo esperable); si no lo
 # recibe, simula quedarse esperando la passphrase (lo que rompía antes).
 mkdir -p "$TMPDIR_TEST/fakebin"
-cat > "$TMPDIR_TEST/fakebin/ssh" <<'FAKESSH'
+local SSH_DISPLAY_LOG="$TMPDIR_TEST/ssh-display.log"
+cat > "$TMPDIR_TEST/fakebin/ssh" <<FAKESSH
 #!/bin/sh
+echo "DISPLAY=\${DISPLAY}" >> "$SSH_DISPLAY_LOG"
 batch=0
-for a in "$@"; do
-  case "$a" in
+for a in "\$@"; do
+  case "\$a" in
     *BatchMode=yes*) batch=1 ;;
   esac
 done
-if [ "$batch" -eq 1 ]; then
+if [ "\$batch" -eq 1 ]; then
   echo "git@fakehost-unreachable: Permission denied (publickey)." >&2
   exit 255
 else
@@ -527,6 +529,11 @@ if [[ -f "$WARN" ]] && grep -q "ssh-add" "$WARN"; then
   pass "El warn sugiere 'ssh-add' para cargar la clave en el agente"
 else
   fail "El warn no sugiere ssh-add: $(cat $WARN 2>/dev/null)"
+fi
+if [[ -f "$SSH_DISPLAY_LOG" ]] && grep -q "^DISPLAY=$" "$SSH_DISPLAY_LOG"; then
+  pass "DISPLAY vacío en background: GNOME Keyring no puede mostrar diálogos"
+else
+  fail "DISPLAY no está vacío en background — GNOME Keyring podría mostrar prompts: $(cat $SSH_DISPLAY_LOG 2>/dev/null)"
 fi
 
 

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -28,6 +28,17 @@ function mw-tools-upgrade() {
     [[ "$arg" == "-v" ]] && verbose=1
   done
 
+  # Evita que git/ssh queden esperando una passphrase sin tener una
+  # terminal interactiva disponible (esto puede colgar el chequeo en
+  # background o, peor, crashear el agente gráfico de ssh-askpass y
+  # romper la sesión ssh para el resto de la terminal). Si la clave no
+  # está cargada en el agente, el fetch/pull falla rápido y se reporta
+  # como error en lugar de pedir la passphrase.
+  local GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10"
+  export GIT_SSH_COMMAND
+  local GIT_TERMINAL_PROMPT=0
+  export GIT_TERMINAL_PROMPT
+
   local today=$(date +%Y-%m-%d)
   local REPOS_MAIN=()
   local REPOS_TO_UPDATE=()
@@ -37,6 +48,7 @@ function mw-tools-upgrade() {
   local REPOS_WITH_FETCH_ERROR=()
   local REPOS_UPDATED=()
   local REPOS_PULL_FAILED=()
+  local has_auth_error=0
 
   # Verifica si ya se revisó hoy
   if [[ -f "$GIT_UPDATE_CHECK_FILE" && $(cat "$GIT_UPDATE_CHECK_FILE") == "$today" ]]; then
@@ -84,7 +96,7 @@ function mw-tools-upgrade() {
       if err=$(git -C $repo_dir remote update 2>&1 >/dev/null); then
         echo 0 > "$tmpdir/$key.tmp"
       else
-        { echo 1; echo "$err" | grep -E "^(fatal|error|ERROR):" | head -1 } > "$tmpdir/$key.tmp"
+        { echo 1; echo "$err" | grep -E "Permission denied|^(fatal|error|ERROR):" | head -1 } > "$tmpdir/$key.tmp"
       fi
       mv "$tmpdir/$key.tmp" "$tmpdir/$key"
     } &
@@ -126,6 +138,7 @@ function mw-tools-upgrade() {
     if [[ "$fetch_exit" != "0" ]]; then
       echo "❌  $repo_name  ❌  ${fetch_error:-fetch failed}"
       REPOS_WITH_FETCH_ERROR+=( $repo_name )
+      [[ "$fetch_error" == *"Permission denied"* ]] && has_auth_error=1
       continue
     fi
     UPDATES=$(LC_ALL=C git -C $repo_dir status -uno | grep -E "Your branch is behind|have diverged")
@@ -144,6 +157,31 @@ function mw-tools-upgrade() {
     fi
   done
   rm -rf $tmpdir
+
+  # Recuperación interactiva ante fallo de auth SSH.
+  # Los fetch corren en paralelo con BatchMode=yes (ver arriba), así que nunca
+  # piden la passphrase mientras tanto: si la clave no está cargada, fallan con
+  # "Permission denied". Cuando hay una terminal (uso manual, no background),
+  # ofrecemos cargar la clave con ssh-add -que pide la passphrase de forma
+  # limpia, una sola vez- y reintentamos todo el chequeo. El guard
+  # _MW_SSH_RETRY evita ofrecerlo de nuevo si tras el ssh-add sigue fallando.
+  if [[ $auto_yes -eq 0 && -t 0 && $has_auth_error -eq 1 && -z "$_MW_SSH_RETRY" ]]; then
+    printf '%0.s-' {1..80}; echo
+    echo "  🔑 Falló la autenticación SSH y tu clave no parece estar cargada en el agente."
+    local retry_ans
+    printf "  ¿Correr 'ssh-add' y reintentar? [Y/n] (default: Y): "
+    read -r retry_ans
+    if [[ -z "$retry_ans" || "$retry_ans" == [yY] ]]; then
+      if ssh-add; then
+        typeset -g _MW_SSH_RETRY=1
+        mw-tools-upgrade "$@"
+        unset _MW_SSH_RETRY
+        return
+      else
+        echo "  ⚠️  ssh-add no cargó ninguna clave; continúo sin reintentar."
+      fi
+    fi
+  fi
 
   if [[ "${#REPOS_TO_UPDATE[@]}" -eq 0 && "${#REPOS_WITH_FETCH_ERROR[@]}" -eq 0 ]]; then
     printf '%0.s-' {1..80}; echo
@@ -196,7 +234,10 @@ function mw-tools-upgrade() {
   local warn_msgs=()
   [[ "${#REPOS_NOT_ON_MAIN[@]}" -ne 0 ]] && warn_msgs+=("  📢 mw-tools: repos en rama no principal: ${(j:, :)REPOS_NOT_ON_MAIN}")
   [[ "${#REPOS_WITH_LOCAL_UPDATES[@]}" -ne 0 ]] && warn_msgs+=("  🚩 mw-tools: cambios locales sin commitear en: ${(j:, :)REPOS_WITH_LOCAL_UPDATES}")
-  [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]] && warn_msgs+=("  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}")
+  if [[ "${#REPOS_WITH_FETCH_ERROR[@]}" -ne 0 ]]; then
+    warn_msgs+=("  ❌ mw-tools: error al hacer fetch de: ${(j:, :)REPOS_WITH_FETCH_ERROR}")
+    [[ $has_auth_error -eq 1 ]] && warn_msgs+=("     Cargá tu clave SSH en el agente con: ssh-add")
+  fi
   [[ "${#REPOS_PULL_FAILED[@]}" -ne 0 ]] && warn_msgs+=("  ❌ mw-tools: falló el pull de: ${(j:, :)REPOS_PULL_FAILED}")
 
   if [[ "${#warn_msgs[@]}" -ne 0 ]]; then

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -28,12 +28,8 @@ function mw-tools-upgrade() {
     [[ "$arg" == "-v" ]] && verbose=1
   done
 
-  # Evita que git/ssh queden esperando una passphrase sin tener una
-  # terminal interactiva disponible (esto puede colgar el chequeo en
-  # background o, peor, crashear el agente gráfico de ssh-askpass y
-  # romper la sesión ssh para el resto de la terminal). Si la clave no
-  # está cargada en el agente, el fetch/pull falla rápido y se reporta
-  # como error en lugar de pedir la passphrase.
+  # Evita que ssh pida la passphrase sin terminal (en background colgaría o
+  # crashearía el askpass): si la clave no está cargada, el fetch falla rápido
   local GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10"
   export GIT_SSH_COMMAND
   local GIT_TERMINAL_PROMPT=0
@@ -158,13 +154,8 @@ function mw-tools-upgrade() {
   done
   rm -rf $tmpdir
 
-  # Recuperación interactiva ante fallo de auth SSH.
-  # Los fetch corren en paralelo con BatchMode=yes (ver arriba), así que nunca
-  # piden la passphrase mientras tanto: si la clave no está cargada, fallan con
-  # "Permission denied". Cuando hay una terminal (uso manual, no background),
-  # ofrecemos cargar la clave con ssh-add -que pide la passphrase de forma
-  # limpia, una sola vez- y reintentamos todo el chequeo. El guard
-  # _MW_SSH_RETRY evita ofrecerlo de nuevo si tras el ssh-add sigue fallando.
+  # Si falló la auth SSH y hay terminal (uso manual), ofrecer ssh-add y
+  # reintentar. El guard _MW_SSH_RETRY evita reintentar en loop
   if [[ $auto_yes -eq 0 && -t 0 && $has_auth_error -eq 1 && -z "$_MW_SSH_RETRY" ]]; then
     printf '%0.s-' {1..80}; echo
     echo "  🔑 Falló la autenticación SSH y tu clave no parece estar cargada en el agente."

--- a/zshrc.mikroways.updates
+++ b/zshrc.mikroways.updates
@@ -28,12 +28,17 @@ function mw-tools-upgrade() {
     [[ "$arg" == "-v" ]] && verbose=1
   done
 
-  # Evita que ssh pida la passphrase sin terminal (en background colgaría o
-  # crashearía el askpass): si la clave no está cargada, el fetch falla rápido
+  # Evita prompts de passphrase sin terminal: BatchMode hace fallar el fetch
+  # rápido si la clave no está cargada; DISPLAY vacío impide que GNOME
+  # Keyring muestre su diálogo gráfico (solo en background, no en uso manual)
   local GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10"
   export GIT_SSH_COMMAND
   local GIT_TERMINAL_PROMPT=0
   export GIT_TERMINAL_PROMPT
+  if [[ $auto_yes -eq 1 ]]; then
+    local DISPLAY=""
+    export DISPLAY
+  fi
 
   local today=$(date +%Y-%m-%d)
   local REPOS_MAIN=()


### PR DESCRIPTION
## Contexto

Al abrir la terminal, el chequeo automático de updates (que corre en background) disparaba el prompt de passphrase vía el askpass gráfico de Ubuntu. Sin terminal controladora, ese agente crasheaba y **rompía la sesión SSH para el resto de la terminal**: a partir de ahí todos los repos fallaban con "No se pudo leer del repositorio remoto", incluso corriendo `mw-tools-force-upgrade` a mano.

Además, al autoactualizar el propio repo de dotfiles en background, `script/install` corría `vim +PlugClean +PlugUpdate +qall` sin TTY y ensuciaba el log con errores de vim ("la entrada no es desde un terminal").

## Cambios

- **`zshrc.mikroways.updates`**: `mw-tools-upgrade` fuerza `GIT_SSH_COMMAND` con `BatchMode=yes` (+ `ConnectTimeout=10`) y `GIT_TERMINAL_PROMPT=0`. Si la clave no está cargada en el agente, el fetch/pull falla rápido y limpio (se reporta en `.warn`) en vez de colgar o crashear el askpass. El scope es local a la función, no contamina el shell. Vacía `DISPLAY` en modo background para que GNOME Keyring tampoco pueda mostrar su diálogo gráfico.
- **Recuperación interactiva**: cuando se corre `mw-tools-upgrade` a mano (hay TTY) y la auth SSH falla, ofrece correr `ssh-add` —que pide la passphrase de forma limpia, una sola vez— y reintenta el chequeo automáticamente. Un guard evita reintentar en loop.
- **Hint preciso**: la sugerencia de `ssh-add` en `.warn` aparece solo ante errores de autenticación, no ante cualquier fallo de fetch (ej. host caído).
- **`script/install`**: omite la actualización de plugins de vim cuando no hay terminal interactiva (`[ -t 0 ] && [ -t 1 ]`), evitando los errores de vim al autoactualizar en background.
- **Tests**: TEST 12 (clave con passphrase no cuelga el chequeo y reporta el error con hint de ssh-add) y TEST 13 (un error de fetch no-auth NO sugiere ssh-add). Suite completa: 33/33.

## Nota

Una clave SSH con passphrase **que no esté cargada en el agente** seguirá sin poder actualizar por SSH automáticamente — no hay forma segura de pedir la passphrase en un proceso de background sin terminal. Lo que este fix garantiza es que eso ya no rompe nada: el repo queda reportado en `.warn` con la sugerencia de `ssh-add`, y el resto sigue funcionando. Documentado en el README.